### PR TITLE
Issue 355 - Minor front page text alignment, visual tweaks and spelling corrections

### DIFF
--- a/FrontPage.md
+++ b/FrontPage.md
@@ -2,35 +2,39 @@
 layout: base
 permalink: /
 style: >
-  text-align: center
+  text-align: left
 ---
 
 <br>
 
 ***
 
-**Welcome to TheCodingTrain's code repository!**
+# Welcome to The Coding Train's Code Repository!
+{: style="text-align: center;"}
 
-Here you can find all videos made on TheCodingTrain with the corresponding code available for download and a working live example running in the browser.
+Here you can find all videos made on [The Coding Train](https://www.youtube.com/channel/UCvjgXvBlbQiydffZU7m1_aw) with the corresponding code available for download and working live examples running in the browser.
 
-Happy Coding!
+_Happy Coding!_
 
 ***
 
 
 ## Coding Challenges
 Watch me take on some viewer submitted Coding Challenges in p5.js and Processing!
+{: style="text-align: center;"}
 {% include 3-modules/video-list.html videos=site.CodingChallenges limit=3 reverse=true %}
 <br>
 
 ## Tutorials
 Here you can find all tutorials made by Daniel Shiffman on TheCodingTrain.  
 If you are searching for tutorials made by guests, you can check them out [here]({{ site.baseurl }}{% link _GuestTutorials/index.md %}).
+{: style="text-align: center;"}
 {% include 3-modules/video-list.html videos=site.Tutorials limit=3 reverse=true %}
 <br>
 
 ## Streams
 Watch all the unedited Live Streams!
+{: style="text-align: center;"}
 {% include 3-modules/video-list.html videos=site.Streams limit=3 reverse=true %}
 <br>
 

--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@
 # --- Site Settings ---
 
 # The site's title.
-title: The Coding Train // Code Reposiory
+title: The Coding Train // Code Repository
 
 # Location from where the site will be served (repository name for GitHub Pages).
 baseurl: /Rainbow-Code
@@ -95,7 +95,7 @@ defaults:
       video_type:       "guest tutorial"
       video_type_short: "tutorial"
       can_contribute:   false
-  
+
   # Courses
   - scope:              { path: "", type: "Courses" }
     values:

--- a/assets/css/2-base/_ctas.sass
+++ b/assets/css/2-base/_ctas.sass
@@ -9,7 +9,7 @@ button,
   vertical-align: middle
   text-align: center
   box-shadow: 0px 6px 0px 0px rgba(0, 0, 0, 0.06)
-  
+
   transition: all 150ms
   transform: scale(1)
 
@@ -18,7 +18,7 @@ button,
     transform: scale(0.98)
 
 a
-  color: $text-color
+  color: $ct-purple
   transition: color 200ms
   text-decoration: underline
 

--- a/assets/css/2-base/_typeface.sass
+++ b/assets/css/2-base/_typeface.sass
@@ -3,7 +3,9 @@ html, body
   color: $text-color
   font-size: 1.6rem
 
-
+p
+  line-height: 2.8rem
+  
 h1, h2, h3, h4, h5, h6,
 button, .cta-button
   font-family: $sans-serif


### PR DESCRIPTION
- paragraph line spacing increased a touch to aid readability
- links made $ct-purple instead of $text-color to make them more visually distinct on the page
- default front page text-alignment changed to 'left' as per Dan's suggestion in one of the GitHub issues for the top text
- specific pieces of text aligned 'center'
(could have done it the other way around, but left-alignment seems more logical as a default?)
- added link to YouTube CT channel in top text