### PR TITLE
Test YAML with PropTypes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:7.10
+      - image: circleci/node:9
 
     steps:
       - checkout

--- a/_Courses/programming-with-text/10-chatbots/10.2-rivescript.md
+++ b/_Courses/programming-with-text/10-chatbots/10.2-rivescript.md
@@ -4,8 +4,9 @@ video_number: 2
 date: 2017-10-12
 video_id: wf8w1BJb9Xc
 can_contribute: true
+repository: false,
 
-links: 
+links:
   - title: "RiveScript"
     url: "https://www.rivescript.com/"
   - title: "jQuery"

--- a/_Courses/programming-with-text/11-chrome-extensions/11.1-introduction.md
+++ b/_Courses/programming-with-text/11-chrome-extensions/11.1-introduction.md
@@ -3,6 +3,7 @@ title: "Introduction to Chrome Extensions"
 video_number: 1
 date: 2017-11-13
 video_id: hkOTAmmuv_4
+repository: false,
 
 videos:
   - title: "Programming with Text playlist"

--- a/_Courses/programming-with-text/11-chrome-extensions/11.1-introduction.md
+++ b/_Courses/programming-with-text/11-chrome-extensions/11.1-introduction.md
@@ -3,7 +3,7 @@ title: "Introduction to Chrome Extensions"
 video_number: 1
 date: 2017-11-13
 video_id: hkOTAmmuv_4
-repository: false,
+repository: false
 
 videos:
   - title: "Programming with Text playlist"

--- a/_Courses/programming-with-text/11-chrome-extensions/11.5-pop-ups.md
+++ b/_Courses/programming-with-text/11-chrome-extensions/11.5-pop-ups.md
@@ -4,6 +4,7 @@ video_number: 5
 date: 2017-11-21
 video_id: YQnRSa8MGwM
 can_contribute: true
+repository: false,
 
 videos:
   - title: "Programming with Text playlist"

--- a/_Courses/programming-with-text/11-chrome-extensions/11.5-pop-ups.md
+++ b/_Courses/programming-with-text/11-chrome-extensions/11.5-pop-ups.md
@@ -4,7 +4,7 @@ video_number: 5
 date: 2017-11-21
 video_id: YQnRSa8MGwM
 can_contribute: true
-repository: false,
+repository: false
 
 videos:
   - title: "Programming with Text playlist"

--- a/_Courses/programming-with-text/2-regular-expressions/2.1-introduction.md
+++ b/_Courses/programming-with-text/2-regular-expressions/2.1-introduction.md
@@ -3,8 +3,9 @@ title: "Introduction to Regular Expressions"
 video_number: 1
 date: 2016-09-15
 video_id: 7DG3kCDx53c
+repository: false
 
-links: 
+links:
   - title: "MDN's Regular Expressions Reference"
     url: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
   - title: "Regular Expressions on Wikipedia"
@@ -15,6 +16,6 @@ links:
     url: https://tisch.nyu.edu/itp
 ---
 
-In this video I introduce Regular Expressions. What are they and how are they used? 
+In this video I introduce Regular Expressions. What are they and how are they used?
 
 I summarize the topics of future videos including meta-characters, capturing parentheses, character classes and JavaScript functions like `split()`, `match()`, `test()`, `replace()` and `exec()`.

--- a/_Courses/programming-with-text/2-regular-expressions/2.10-homework-assignments.md
+++ b/_Courses/programming-with-text/2-regular-expressions/2.10-homework-assignments.md
@@ -4,6 +4,7 @@ video_number: 10
 date: 2016-09-19
 video_id: pMn44yFxGWk
 can_contribute: true
+repository: false
 ---
 
-In this short video I discuss a creative assignment around the topic of Regular Expressions in Week 2 of "Programming from A to Z". 
+In this short video I discuss a creative assignment around the topic of Regular Expressions in Week 2 of "Programming from A to Z".

--- a/_Courses/programming-with-text/2-regular-expressions/2.2-meta-characters.md
+++ b/_Courses/programming-with-text/2-regular-expressions/2.2-meta-characters.md
@@ -3,8 +3,9 @@ title: "Meta-characters"
 video_number: 2
 date: 2016-09-16
 video_id: YTocEnDsMNw
+repository: false
 
-links: 
+links:
   - title: "MDN's Regular Expressions Reference"
     url: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
   - title: "Regular Expressions on Wikipedia"

--- a/_Courses/programming-with-text/2-regular-expressions/2.3-character-classes.md
+++ b/_Courses/programming-with-text/2-regular-expressions/2.3-character-classes.md
@@ -3,8 +3,9 @@ title: "Character Classes"
 video_number: 3
 date: 2016-09-16
 video_id: EfJU0Y9WAZ4
+repository: false
 
-links: 
+links:
   - title: "MDN's Regular Expressions Reference"
     url: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
   - title: "Regular Expressions on Wikipedia"
@@ -15,4 +16,4 @@ links:
     url: https://tisch.nyu.edu/itp
 ---
 
-In this video, I explain character classes which are a way of matching a selection of characters in a regular expression. 
+In this video, I explain character classes which are a way of matching a selection of characters in a regular expression.

--- a/_Courses/programming-with-text/2-regular-expressions/2.4-capturing-groups.md
+++ b/_Courses/programming-with-text/2-regular-expressions/2.4-capturing-groups.md
@@ -3,8 +3,9 @@ title: "Capturing Groups"
 video_number: 4
 date: 2016-09-17
 video_id: c9HbsUSWilw
+repository: false
 
-links: 
+links:
   - title: "MDN's Regular Expressions Reference"
     url: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
   - title: "Regular Expressions on Wikipedia"
@@ -15,4 +16,4 @@ links:
     url: https://tisch.nyu.edu/itp
 ---
 
-In this video I discuss capturing parentheses and how they are used to create numbered groups that referenced in a find/replace operation. 
+In this video I discuss capturing parentheses and how they are used to create numbered groups that referenced in a find/replace operation.

--- a/_Courses/programming-with-text/2-regular-expressions/2.5-back-references.md
+++ b/_Courses/programming-with-text/2-regular-expressions/2.5-back-references.md
@@ -3,8 +3,9 @@ title: "Back References"
 video_number: 5
 date: 2016-09-18
 video_id: Z66TeSTcP-Q
+repository: false
 
-links: 
+links:
   - title: "MDN's Regular Expressions Reference"
     url: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
   - title: "Regular Expressions on Wikipedia"

--- a/_GuestTutorials/6-golan-levin-modulo-operator.md
+++ b/_GuestTutorials/6-golan-levin-modulo-operator.md
@@ -4,6 +4,7 @@ video_number: 6
 date: 2017-10-24
 video_id: r5Iy3v1co0A
 can_contribute: true
+repository: false
 
 custom_sections:
 
@@ -17,4 +18,4 @@ custom_sections:
 
 Golan Levin visits the Coding Train studio for a tutorial about the modulo operator. He explains what modulus means and its applications in creative coding with p5.js and Processing.
 
-Golan Levin is an artist and educator living in Pittsburgh. He teaches at Carnegie Mellon University, where he also directs the STUDIO for Creative Inquiry, an interdisciplinary arts-research center. 
+Golan Levin is an artist and educator living in Pittsburgh. He teaches at Carnegie Mellon University, where he also directs the STUDIO for Creative Inquiry, an interdisciplinary arts-research center.

--- a/_GuestTutorials/7-golan-levin-circle-morphing.md
+++ b/_GuestTutorials/7-golan-levin-circle-morphing.md
@@ -4,6 +4,7 @@ video_number: 7
 date: 2017-10-25
 video_id: mvgcNOX8JGQ
 can_contribute: true
+repository: false
 
 custom_sections:
 
@@ -15,4 +16,4 @@ custom_sections:
       url: "http://www.flong.com/"
 ---
 
-This video is all about interpolation. Artist and educator Golan Levin provides historical background and then proposes a "circle morphing" coding challenge. 
+This video is all about interpolation. Artist and educator Golan Levin provides historical background and then proposes a "circle morphing" coding challenge.

--- a/_Streams/106.1-chrome-extensions-part-1.md
+++ b/_Streams/106.1-chrome-extensions-part-1.md
@@ -46,9 +46,8 @@ videos:
   - title: "Instance Mode"
     url: /Tutorials/9-additional-topics/9.11-instance-mode
 
-  
-parts:
 
+custom_sections:
   - title: "List of Chrome Extensions mentioned"
     items:
       - title: "Decodelia"

--- a/_Streams/106.2-chrome-extensions-part-2.md
+++ b/_Streams/106.2-chrome-extensions-part-2.md
@@ -38,9 +38,8 @@ videos:
   - title: "Instance Mode"
     url: /Tutorials/9-additional-topics/9.11-instance-mode
 
-  
-parts:
 
+custom_sections:
   - title: "List of Chrome Extensions mentioned"
     items:
       - title: "Decodelia"

--- a/_Streams/108-nn-continued.md
+++ b/_Streams/108-nn-continued.md
@@ -1,9 +1,0 @@
----
-title: "Upcoming Live Stream"
-video_number: 108
-date: 2018-1-12 10:30:00
----
-
-Topics:
-- Continue machine learning
-- Image Stippling Challenge?

--- a/_Streams/108-nn-continued.md
+++ b/_Streams/108-nn-continued.md
@@ -1,7 +1,7 @@
 ---
 title: "Upcoming Live Stream"
 video_number: 108
-date: 2018-1-12 10:30am
+date: 2018-1-12 10:30:00
 ---
 
 Topics:

--- a/_Streams/110-webgl-with-p5js-continued.md
+++ b/_Streams/110-webgl-with-p5js-continued.md
@@ -16,7 +16,6 @@ topics:
     url: "/Tutorials/18-webgl/18.5-camera"
   - title: "Debugging Open Source projects"
     time: "2:15:34"
-    url: false 
 
 links:
   - title: "Getting started with WebGL in p5"

--- a/_Streams/124-upcoming.md
+++ b/_Streams/124-upcoming.md
@@ -1,7 +1,7 @@
 ---
 title: "Upcoming Live Stream"
 video_number: 124
-date: 2018-03-09 10:30AM 
+date: 2018-03-09 10:30:00
 ---
 
 Topics TBA

--- a/unit_testing/coding-challange-yaml.test.js
+++ b/unit_testing/coding-challange-yaml.test.js
@@ -13,6 +13,7 @@ everything needed to create this script.
 // import libraries.
 const yaml = require('js-yaml'); // js-yaml helps us read yaml of files
 const fs = require('fs'); // fs is file system package
+const path = require('path');
 // Use check-prop-types to turn PropTypes messages into errors
 const { assertPropTypes } = require('check-prop-types');
 // PropTypes of the documents are descibed in the formats.js file.
@@ -21,91 +22,109 @@ const formatDefinitions = require('./formats.js');
 // if verbose set to true script will log almost everything it does.
 let verbose = false;
 
-// Create variable with path to _CodingChallenges directory
-let CodingChallangesDir = "../_CodingChallenges";
+// Create variable with path to directories to check, and check them
+// against their specified format
+let directories = {
+  _CodingChallenges: formatDefinitions.video,
+  _Courses: formatDefinitions.video,
+  _GuestTutorials: formatDefinitions.video,
+  _Streams: formatDefinitions.stream,
+  _Tutorials: formatDefinitions.video,
+};
 
-// test that  script can read _CodingChallanges directory with fs.readdirSync
-// as it will imediatly throw an error if can't read directory (fs.readdir is
-// asyncronous and so test will pass despite not being able to read directory).
-test('Check that script can read _CodingChallanges directory.', () => {
-  let files = fs.readdirSync(CodingChallangesDir);
-  if (verbose) {
-    console.log("_CodingChallanges directory successfully read, here are all the files:");
-    files.forEach((file) => console.log("\t" + file));
-  }
+const checkFolder = (videoFormat, previousPath, folder) => describe(folder, () => {
+  expect(videoFormat).toBeDefined();
+  expect(previousPath).toBeDefined();
+  expect(folder).toBeDefined();
+  // Assuming _CodingChallanges directory readable, go on to run a bunch of tests
+  // on each file in the directory to check that all files are valid.
+  // TODO: only run this if first test readable.
+  let currentPath = path.join(previousPath, folder);
+  let directories = [];
+  let files = [];
+  fs.readdirSync(currentPath).forEach(fileName => {
+    let fullPath = path.join(currentPath, fileName);
+    if(fs.lstatSync(fullPath).isDirectory()) {
+      directories.push(fileName);
+    } else {
+      files.push(fileName);
+    }
+  });
+
+  directories.forEach(dir => checkFolder(videoFormat, currentPath, dir));
+
+  expect(files).toContain('index.md');
+  let indexPosition = files.indexOf('index.md');
+  files.splice(indexPosition, 1);
+
+
+  test('index.md is valid', () => {
+    let filePath = path.join(currentPath, 'index.md');
+    let contents = fs.readFileSync(filePath, 'utf8');
+    let yamlContents = contents.split("---")[1];
+    const frontYaml = yaml.safeLoad(yamlContents);
+    assertPropTypes(formatDefinitions.series, frontYaml, "YAML", 'index.md');
+  });
+
+  files.forEach((fileName) => describe(fileName, () => {
+    let filePath = path.join(currentPath, fileName);
+    // First test if script can read file. Does this using fs.readFileSync() as
+    // fs.readFile() is asynchronous so test passed when it shouldn't have.
+    // Potential errors may include: wrong encoding, wrong privaliges.
+    // TODO: create an example where this test fails, but directory path is
+    // correct to check it works
+    let contents = fs.readFileSync(filePath, 'utf8');
+    if (verbose) {
+      console.log("Successfully read contents of " + filePath + ":")
+      console.log(contents);
+    }
+
+    // Then check if file has oppening and closing "---"s. The "---"s contain the
+    // YAML. Test does this by splitting the string by "---"s then getting the
+    // number of "---"s by subtracting one from the number of resulting sections
+    // (empty sections are returned even if a "---" is right at beggining of
+    // string). If this doesn't make sense even after reading the code, I
+    // reccomend looking at the MDN page on string splitting:
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split
+    test("has oppening and closing '---'s", () => {
+      expect(contents.split("---").length-1).toBe(2);
+      if (verbose) {
+        console.log("YAML from " + filePath + " has oppening and closing '---'s");
+      }
+    });
+
+    // Checks YAML section is at beggining. Not sure if causes error if this is
+    // not the case. Does this by splitting contents by "---"s, then checking that
+    // the first section (which will be everything before the first "---") has a
+    // length of 0 (Nothing before first "---").
+    test("has YAML section at beggining", () => {
+      expect(contents.split("---")[0].length).toBe(0);
+      if (verbose) {
+        console.log("YAML from " + filePath + " is at beggining.");
+      }
+    });
+
+    // Checks YAML section is not empty. Does this by splitting contents by
+    // "---"s, then checking that the second section (which will be everything
+    // in the YAML section) has a length greater than 0 (is not empty).
+    test("does not have an empty YAML section", () => {
+      expect(contents.split("---")[1].length>0).toBe(true);
+      if (verbose) {
+        console.log("YAML from " + filePath + " has non zero length.");
+      }
+    });
+
+    // Uses PropTypes to validate the structure and types of all of the
+    // parts of the YAML, including if there are keys that don't exist
+    // in the definition
+    test("has valid YAML layout and types", () => {
+      let yamlContents = contents.split("---")[1];
+      const frontYaml = yaml.safeLoad(yamlContents);
+      assertPropTypes(videoFormat, frontYaml, "YAML", fileName);
+    });
+  }));
 });
 
-// Assuming _CodingChallanges directory readable, go on to run a bunch of tests
-// on each file in the directory to check that all files are valid.
-// TODO: only run this if first test readable.
-let files = fs.readdirSync(CodingChallangesDir);
-files.forEach((file) => describe("Coding Challenge " + file, () => {
-  // First test if script can read file. Does this using fs.readFileSync() as
-  // fs.readFile() is asynchronous so test passed when it shouldn't have.
-  // Potential errors may include: wrong encoding, wrong privaliges.
-  // TODO: create an example where this test fails, but directory path is
-  // correct to check it works
-  let contents = fs.readFileSync(CodingChallangesDir+"/"+file, 'utf8');
-  if (verbose) {
-    console.log("Successfully read contents of _CodingChallenges/"+file+":")
-    console.log(contents);
-  }
-
-  // Then check if file has oppening and closing "---"s. The "---"s contain the
-  // YAML. Test does this by splitting the string by "---"s then getting the
-  // number of "---"s by subtracting one from the number of resulting sections
-  // (empty sections are returned even if a "---" is right at beggining of
-  // string). If this doesn't make sense even after reading the code, I
-  // reccomend looking at the MDN page on string splitting:
-  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split
-  test("has oppening and closing '---'s", () => {
-    expect(contents.split("---").length-1).toBe(2);
-    if (verbose) {
-      console.log("YAML from " + CodingChallangesDir+"/"+file + " has oppening and closing '---'s");
-    }
-  });
-
-  // Checks YAML section is at beggining. Not sure if causes error if this is
-  // not the case. Does this by splitting contents by "---"s, then checking that
-  // the first section (which will be everything before the first "---") has a
-  // length of 0 (Nothing before first "---").
-  test("has YAML section at beggining", () => {
-    expect(contents.split("---")[0].length).toBe(0);
-    if (verbose) {
-      console.log("YAML from " + CodingChallangesDir+"/"+file + " is at beggining.");
-    }
-  });
-
-  // Checks YAML section is not empty. Does this by splitting contents by
-  // "---"s, then checking that the second section (which will be everything
-  // in the YAML section) has a length greater than 0 (is not empty).
-  test("does not have an empty YAML section", () => {
-    expect(contents.split("---")[1].length>0).toBe(true);
-    if (verbose) {
-      console.log("YAML from " + CodingChallangesDir+"/"+file + " has non zero length.");
-    }
-  });
-
-  // Checks YAML is valid. Does this by reading YAML using yml-js library which
-  // will cause error if yaml is invalid.
-  test("has valid YAML contents", () => {
-    let yamlContents = contents.split("---")[1];
-    const frontYaml = yaml.safeLoad(yamlContents);
-    const indentedJson = JSON.stringify(frontYaml, null, 4);
-    if (verbose) {
-      console.log("YAML from " + CodingChallangesDir+"/"+file + " successfully converted to JSON.");
-      console.log("Here is the JSON:");
-      console.log(indentedJson);
-    }
-  });
-
-  // Uses PropTypes to validate the structure and types of all of the
-  // parts of the YAML, including if there are keys that don't exist
-  // in the definition
-  test("has valid YAML layout and types", () => {
-    if(file === "index.md") return;
-    let yamlContents = contents.split("---")[1];
-    const frontYaml = yaml.safeLoad(yamlContents);
-    assertPropTypes(formatDefinitions.video, frontYaml, "YAML", file);
-  });
-}));
+// Do the checks
+Object.entries(directories)
+  .map(([directory, videoFormat]) => checkFolder(videoFormat, "../", directory));

--- a/unit_testing/coding-challange-yaml.test.js
+++ b/unit_testing/coding-challange-yaml.test.js
@@ -66,6 +66,12 @@ const checkFolder = (videoFormat, previousPath, folder) => describe(folder, () =
     assertPropTypes(formatDefinitions.series, frontYaml, "YAML", 'index.md');
   });
 
+  test('files are uniquely numbered', () => {
+    let numbers = files.map(fileName => fileName.split('-')[0]);
+    let numberSet = new Set(numbers);
+    expect(numbers).toHaveLength(numberSet.size);
+  });
+
   files.forEach((fileName) => describe(fileName, () => {
     let filePath = path.join(currentPath, fileName);
     // First test if script can read file. Does this using fs.readFileSync() as

--- a/unit_testing/coding-challange-yaml.test.js
+++ b/unit_testing/coding-challange-yaml.test.js
@@ -13,36 +13,13 @@ everything needed to create this script.
 // import libraries.
 const yaml = require('js-yaml'); // js-yaml helps us read yaml of files
 const fs = require('fs'); // fs is file system package
+// Use check-prop-types to turn PropTypes messages into errors
+const { assertPropTypes } = require('check-prop-types');
+// PropTypes of the documents are descibed in the formats.js file.
+const formatDefinitions = require('./formats.js');
 
 // if verbose set to true script will log almost everything it does.
 let verbose = false;
-
-// define all functions used later
-
-/*
-TODO: clear up this discription
-
-checkHasUndefinedRecursive() checks if an object has undefined or null
-properties, and if it doesn't but it has properties which are objects,
-recursivly check the properties to see if the have an undefined property.
-
-Is used to check if YAML has undeined feilds.
-*/
-function checkHasUndefinedRecursive(value) {
-  if (value == null) { //this checks for undefined as undefined == null is true
-    return true;
-  }
-  // If value is an object, test all of it's properties.
-  if (value instanceof Object) {
-    accumulator = false;
-    for (let key in value) {
-      accumulator = accumulator || checkHasUndefinedRecursive(value[key]);
-    }
-    return accumulator;
-  }
-  // if value is not an object or null or undefined (i.e. an int), return false.
-  return false;
-}
 
 // Create variable with path to _CodingChallenges directory
 let CodingChallangesDir = "../_CodingChallenges";
@@ -62,19 +39,17 @@ test('Check that script can read _CodingChallanges directory.', () => {
 // on each file in the directory to check that all files are valid.
 // TODO: only run this if first test readable.
 let files = fs.readdirSync(CodingChallangesDir);
-files.forEach((file) => {
+files.forEach((file) => describe("Coding Challenge " + file, () => {
   // First test if script can read file. Does this using fs.readFileSync() as
   // fs.readFile() is asynchronous so test passed when it shouldn't have.
   // Potential errors may include: wrong encoding, wrong privaliges.
   // TODO: create an example where this test fails, but directory path is
   // correct to check it works
-  test("Check that we can read contents of "+CodingChallangesDir+"/"+file, () => {
-    let contents = fs.readFileSync(CodingChallangesDir+"/"+file, 'utf8'); // will throw err if can't open file.
-    if (verbose) {
-      console.log("Successfully read contents of _CodingChallenges/"+file+":")
-      console.log(contents);
-    }
-  });
+  let contents = fs.readFileSync(CodingChallangesDir+"/"+file, 'utf8');
+  if (verbose) {
+    console.log("Successfully read contents of _CodingChallenges/"+file+":")
+    console.log(contents);
+  }
 
   // Then check if file has oppening and closing "---"s. The "---"s contain the
   // YAML. Test does this by splitting the string by "---"s then getting the
@@ -83,8 +58,7 @@ files.forEach((file) => {
   // string). If this doesn't make sense even after reading the code, I
   // reccomend looking at the MDN page on string splitting:
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split
-  test("Check that contents of "+CodingChallangesDir+"/"+file+" has oppening and closing '---'s", () => {
-    let contents = fs.readFileSync(CodingChallangesDir+"/"+file, 'utf8');
+  test("has oppening and closing '---'s", () => {
     expect(contents.split("---").length-1).toBe(2);
     if (verbose) {
       console.log("YAML from " + CodingChallangesDir+"/"+file + " has oppening and closing '---'s");
@@ -95,8 +69,7 @@ files.forEach((file) => {
   // not the case. Does this by splitting contents by "---"s, then checking that
   // the first section (which will be everything before the first "---") has a
   // length of 0 (Nothing before first "---").
-  test("Check that contents of "+CodingChallangesDir+"/"+file+" has YAML section at beggining", () => {
-    let contents = fs.readFileSync(CodingChallangesDir+"/"+file, 'utf8');
+  test("has YAML section at beggining", () => {
     expect(contents.split("---")[0].length).toBe(0);
     if (verbose) {
       console.log("YAML from " + CodingChallangesDir+"/"+file + " is at beggining.");
@@ -106,8 +79,7 @@ files.forEach((file) => {
   // Checks YAML section is not empty. Does this by splitting contents by
   // "---"s, then checking that the second section (which will be everything
   // in the YAML section) has a length greater than 0 (is not empty).
-  test("Check that contents of "+CodingChallangesDir+"/"+file+" does not have empty YAML section", () => {
-    let contents = fs.readFileSync(CodingChallangesDir+"/"+file, 'utf8');
+  test("does not have an empty YAML section", () => {
     expect(contents.split("---")[1].length>0).toBe(true);
     if (verbose) {
       console.log("YAML from " + CodingChallangesDir+"/"+file + " has non zero length.");
@@ -116,8 +88,7 @@ files.forEach((file) => {
 
   // Checks YAML is valid. Does this by reading YAML using yml-js library which
   // will cause error if yaml is invalid.
-  test("Check that YAML contents of "+CodingChallangesDir+"/"+file+" valid", () => {
-    let contents = fs.readFileSync(CodingChallangesDir+"/"+file, 'utf8');
+  test("has valid YAML contents", () => {
     let yamlContents = contents.split("---")[1];
     const frontYaml = yaml.safeLoad(yamlContents);
     const indentedJson = JSON.stringify(frontYaml, null, 4);
@@ -128,75 +99,13 @@ files.forEach((file) => {
     }
   });
 
-  // Checks that the YAML page has the required properties. Does this by
-  // oppening yaml, then using the "hasOwnProperty" method to check if it has
-  // all the required properties.
-  //    The required properties are: "title", "video_number", "date", "video_id"
-  // these properties were found at the Content Contribution Guide:
-  // https://github.com/CodingTrain/website/wiki/Content-Contribution-Guide
-  // The required properties for the index.md page was set to be the properties
-  // that apperead across all index.md pages in all directories.
-  test("Check that YAML contents of "+CodingChallangesDir+"/"+file
-  +" have required properties", () => {
-    let contents = fs.readFileSync(CodingChallangesDir+"/"+file, 'utf8');
+  // Uses PropTypes to validate the structure and types of all of the
+  // parts of the YAML, including if there are keys that don't exist
+  // in the definition
+  test("has valid YAML layout and types", () => {
+    if(file === "index.md") return;
     let yamlContents = contents.split("---")[1];
     const frontYaml = yaml.safeLoad(yamlContents);
-    let requiredProperties = ["title", "video_number", "date", "video_id"];
-    if (file=="index.md") {
-      requiredProperties = ["title", "layout"];
-    }
-    for (let key of requiredProperties) {
-      expect(frontYaml.hasOwnProperty(key)).toBe(true);
-    }
+    assertPropTypes(formatDefinitions.video, frontYaml, "YAML", file);
   });
-
-  // Checks if object created from YAML has any undefined properties using
-  // checkHasUndefinedRecursive function (defined line 32).
-  //     I didn't cause an error to website when videos property was null. I
-  // don't know if undefined properties will always be handled cleanly. if so,
-  // maybe add a "strict" variable, and only run this test if trict is set to
-  // true.
-  test("Check no undefined properties of object from YAML of "+
-    CodingChallangesDir+"/"+file, () => {
-    let contents = fs.readFileSync(CodingChallangesDir+"/"+file, 'utf8');
-    let yamlContents = contents.split("---")[1];
-    const frontYaml = yaml.safeLoad(yamlContents);
-    if (checkHasUndefinedRecursive(frontYaml)) {
-      console.log("There was an undefined property in the object created from the YAML of "+
-        CodingChallangesDir+"/"+file+" here is the object:");
-      console.log(frontYaml);
-    }
-    expect(checkHasUndefinedRecursive(frontYaml)).toBe(false);
-  });
-
-  // Checks that all contributions have the required properties using
-  // .hasOwnProperty method.
-  test("Check that contributions of "+ CodingChallangesDir+"/"+file
-  +" has required properties", () => {
-    let contents = fs.readFileSync(CodingChallangesDir+"/"+file, 'utf8');
-    let yamlContents = contents.split("---")[1];
-    const frontYaml = yaml.safeLoad(yamlContents);
-    if (frontYaml.hasOwnProperty("contributions")) {
-      for (let contibutor of frontYaml["contributions"]) {
-        expect(contibutor.hasOwnProperty("title")).toBe(true);
-        expect(contibutor.hasOwnProperty("url")
-        || contibutor.hasOwnProperty("source")).toBe(true);
-        /************ IMPORTANT NOTE **********************
-          The Community Contributions Guide
-          (https://github.com/CodingTrain/website/wiki/Community-Contributions-Guide)
-          specifies that a user should include the following feilds in their
-          contribution: title, author.name and url. However when I tested that
-          this was the case I found contributer "bobvoorneveld" had chosen not
-          to include a url, but had chosen to include a link to his source code.
-          This seems reasonable as his projects were made with xcode and so it
-          would be hard to share an excecutable, and his decision didn't seem to
-          break anything. In order to allow his and others decisions to omit the
-          url but include source, I changed the test to allow for it. Maybe it
-          should throw an error if a "strict" variable is set to true.
-        ***************************************************/
-        expect(contibutor.hasOwnProperty("author")).toBe(true);
-        expect(contibutor["author"].hasOwnProperty("name")).toBe(true);
-      }
-    }
-  });
-});
+}));

--- a/unit_testing/formats.js
+++ b/unit_testing/formats.js
@@ -1,0 +1,41 @@
+const PropTypes = require('prop-types');
+const exact = require('prop-types-exact');
+
+const link = module.exports.link = exact({
+  title: PropTypes.string.isRequired,
+  author: PropTypes.oneOfType([
+    PropTypes.shape(exact({
+      name: PropTypes.string.isRequired,
+      url: PropTypes.string,
+    })),
+    PropTypes.string,
+  ]),
+  time: PropTypes.string,
+  url: PropTypes.string,
+  video_id: PropTypes.string,
+  playlist_id: PropTypes.string,
+  source: PropTypes.string,
+})
+
+const video = module.exports.video = exact({
+  title: PropTypes.string.isRequired,
+  video_number: PropTypes.number.isRequired,
+  date: PropTypes.instanceOf(Date).isRequired,
+  video_id: PropTypes.string.isRequired,
+  repository: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.oneOf([false]),
+  ]),
+  live_example: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.oneOf([false]),
+  ]),
+  can_contribute: PropTypes.bool,
+  topics: PropTypes.arrayOf(PropTypes.shape(link)),
+  links: PropTypes.arrayOf(PropTypes.shape(link)),
+  videos: PropTypes.arrayOf(PropTypes.shape(link)),
+  books: PropTypes.arrayOf(PropTypes.shape(link)),
+  tools: PropTypes.arrayOf(PropTypes.shape(link)),
+  parts: PropTypes.arrayOf(PropTypes.shape(link)),
+  contributions: PropTypes.arrayOf(PropTypes.shape(link)),
+});

--- a/unit_testing/formats.js
+++ b/unit_testing/formats.js
@@ -22,15 +22,16 @@ const contribution = module.exports.contribution = exact({
   author: link.author.isRequired,
 });
 
-const video = module.exports.video = exact({
+const customSection = module.exports.customSection = exact({
+  title: PropTypes.string.isRequired,
+  items: PropTypes.arrayOf(PropTypes.shape(link)).isRequired,
+});
+
+const videoBase = module.exports.videoBase = exact({
   title: PropTypes.string.isRequired,
   video_number: PropTypes.number.isRequired,
   date: PropTypes.instanceOf(Date).isRequired,
-  video_id: PropTypes.string.isRequired,
-  repository: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.oneOf([false]),
-  ]).isRequired,
+  video_id: PropTypes.string,
   live_example: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.oneOf([false]),
@@ -43,4 +44,26 @@ const video = module.exports.video = exact({
   tools: PropTypes.arrayOf(PropTypes.shape(link)),
   parts: PropTypes.arrayOf(PropTypes.shape(link)),
   contributions: PropTypes.arrayOf(PropTypes.shape(contribution)),
+  custom_sections: PropTypes.arrayOf(PropTypes.shape(customSection)),
+});
+
+const video = module.exports.video = exact({
+  ...videoBase,
+  repository: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.oneOf([false]),
+  ]),
+  video_id: videoBase.video_id.isRequired,
+});
+
+const stream = module.exports.stream = exact({
+  ...videoBase
+});
+
+const series = module.exports.series = exact({
+  title: PropTypes.string.isRequired,
+  subtitle: PropTypes.string,
+  layout: PropTypes.oneOf(['series-index']),
+  series_number: PropTypes.number,
+  reverse: PropTypes.bool,
 });

--- a/unit_testing/formats.js
+++ b/unit_testing/formats.js
@@ -15,7 +15,12 @@ const link = module.exports.link = exact({
   video_id: PropTypes.string,
   playlist_id: PropTypes.string,
   source: PropTypes.string,
-})
+});
+
+const contribution = module.exports.contribution = exact({
+  ...link,
+  author: link.author.isRequired,
+});
 
 const video = module.exports.video = exact({
   title: PropTypes.string.isRequired,
@@ -25,7 +30,7 @@ const video = module.exports.video = exact({
   repository: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.oneOf([false]),
-  ]),
+  ]).isRequired,
   live_example: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.oneOf([false]),
@@ -37,5 +42,5 @@ const video = module.exports.video = exact({
   books: PropTypes.arrayOf(PropTypes.shape(link)),
   tools: PropTypes.arrayOf(PropTypes.shape(link)),
   parts: PropTypes.arrayOf(PropTypes.shape(link)),
-  contributions: PropTypes.arrayOf(PropTypes.shape(link)),
+  contributions: PropTypes.arrayOf(PropTypes.shape(contribution)),
 });

--- a/unit_testing/package-lock.json
+++ b/unit_testing/package-lock.json
@@ -156,6 +156,12 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
+    },
     "asn1": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
@@ -560,6 +566,12 @@
         "supports-color": "5.3.0"
       }
     },
+    "check-prop-types": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/check-prop-types/-/check-prop-types-1.1.2.tgz",
+      "integrity": "sha512-hGDrZ1yhRgKuP1yzZ5sUX/PPmlKBLOF1GyF0Z008Sienko3BFZmlCXnmq+npRTIL/WlFCUzThyd+F5PQnnT1ug==",
+      "dev": true
+    },
     "ci-info": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
@@ -794,6 +806,15 @@
         "jsbn": "0.1.1"
       }
     },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "0.4.19"
+      }
+    },
     "error-ex": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
@@ -989,6 +1010,29 @@
         "bser": "2.0.0"
       }
     },
+    "fbjs": {
+      "version": "0.8.16",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+      "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+      "dev": true,
+      "requires": {
+        "core-js": "1.2.7",
+        "isomorphic-fetch": "2.2.1",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "promise": "7.3.1",
+        "setimmediate": "1.0.5",
+        "ua-parser-js": "0.7.17"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+          "dev": true
+        }
+      }
+    },
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
@@ -1070,910 +1114,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
-    },
-    "fsevents": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
-      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "nan": "2.9.2",
-        "node-pre-gyp": "0.6.39"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ajv": {
-          "version": "4.11.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "aproba": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.2.9"
-          }
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "balanced-match": {
-          "version": "0.4.2",
-          "bundled": true,
-          "dev": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "block-stream": {
-          "version": "0.0.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3"
-          }
-        },
-        "boom": {
-          "version": "2.10.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "brace-expansion": {
-          "version": "1.1.7",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "balanced-match": "0.4.2",
-            "concat-map": "0.0.1"
-          }
-        },
-        "buffer-shims": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "co": {
-          "version": "4.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "debug": {
-          "version": "2.6.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-extend": {
-          "version": "0.4.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "detect-libc": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "extend": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "extsprintf": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "fstream": {
-          "version": "1.0.11",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
-          }
-        },
-        "fstream-ignore": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
-          }
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aproba": "1.1.1",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
-          }
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true,
-          "dev": true
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "bundled": true,
-          "dev": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.0",
-            "sshpk": "1.13.0"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "ini": {
-          "version": "1.3.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jodid25519": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsonify": "0.0.0"
-          }
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jsprim": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.0.2",
-            "json-schema": "0.2.3",
-            "verror": "1.3.6"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "mime-db": {
-          "version": "1.27.0",
-          "bundled": true,
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.15",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "mime-db": "1.27.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true,
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "node-pre-gyp": {
-          "version": "0.6.39",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "detect-libc": "1.0.2",
-            "hawk": "3.1.3",
-            "mkdirp": "0.5.1",
-            "nopt": "4.0.1",
-            "npmlog": "4.1.0",
-            "rc": "1.2.1",
-            "request": "2.81.0",
-            "rimraf": "2.6.1",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.0"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "bundled": true,
-          "dev": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "qs": {
-          "version": "6.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.2.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.1",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "request": {
-          "version": "2.81.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.0.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "glob": "7.1.2"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "semver": {
-          "version": "5.3.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "sshpk": {
-          "version": "1.13.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jodid25519": "1.0.2",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "2.2.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
-          }
-        },
-        "tar-pack": {
-          "version": "3.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "debug": "2.6.8",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.2.9",
-            "rimraf": "2.6.1",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "verror": {
-          "version": "1.3.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "extsprintf": "1.0.2"
-          }
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "string-width": "1.0.2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        }
-      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -2120,6 +1260,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true
     },
     "hawk": {
@@ -2401,6 +1547,16 @@
       "dev": true,
       "requires": {
         "isarray": "1.0.0"
+      }
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "dev": true,
+      "requires": {
+        "node-fetch": "1.7.3",
+        "whatwg-fetch": "2.0.3"
       }
     },
     "isstream": {
@@ -3194,18 +2350,21 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
-    "nan": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
-      "integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw==",
-      "dev": true,
-      "optional": true
-    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "dev": true,
+      "requires": {
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
+      }
     },
     "node-int64": {
       "version": "0.4.0",
@@ -3284,6 +2443,18 @@
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
       "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
       "dev": true
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "function-bind": "1.1.1",
+        "has-symbols": "1.0.0",
+        "object-keys": "1.0.11"
+      }
     },
     "object.getownpropertydescriptors": {
       "version": "2.0.3",
@@ -3544,6 +2715,36 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
       "dev": true
+    },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "dev": true,
+      "requires": {
+        "asap": "2.0.6"
+      }
+    },
+    "prop-types": {
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+      "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+      "dev": true,
+      "requires": {
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
+      }
+    },
+    "prop-types-exact": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prop-types-exact/-/prop-types-exact-1.1.2.tgz",
+      "integrity": "sha512-3x4BWv7w2luSStiHwSzrhK9U1sm+vHwSyg9le2RfY41pZyJdiPKDOKh6TCQywwl++SCr7MMKu7POp4LU/L/eIA==",
+      "dev": true,
+      "requires": {
+        "has": "1.0.1",
+        "object.assign": "4.1.0"
+      }
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -3829,7 +3030,6 @@
         "anymatch": "1.3.2",
         "exec-sh": "0.2.1",
         "fb-watchman": "2.0.0",
-        "fsevents": "1.1.3",
         "minimatch": "3.0.4",
         "minimist": "1.2.0",
         "walker": "1.0.7",
@@ -3860,6 +3060,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
       "dev": true
     },
     "shebang-command": {
@@ -4163,6 +3369,12 @@
         "prelude-ls": "1.1.2"
       }
     },
+    "ua-parser-js": {
+      "version": "0.7.17",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
+      "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g==",
+      "dev": true
+    },
     "uglify-js": {
       "version": "2.8.29",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
@@ -4290,6 +3502,12 @@
       "requires": {
         "iconv-lite": "0.4.19"
       }
+    },
+    "whatwg-fetch": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ=",
+      "dev": true
     },
     "whatwg-url": {
       "version": "6.4.0",

--- a/unit_testing/package.json
+++ b/unit_testing/package.json
@@ -10,6 +10,9 @@
   "author": "MeaningOf42",
   "license": "MIT",
   "devDependencies": {
-    "jest": "^22.4.2"
+    "jest": "^22.4.2",
+    "check-prop-types": "^1.1.2",
+    "prop-types": "^15.6.1",
+    "prop-types-exact": "^1.1.2"
   }
 }

--- a/unit_testing/yaml.test.js
+++ b/unit_testing/yaml.test.js
@@ -128,6 +128,24 @@ const checkFolder = (videoFormat, previousPath, folder) => describe(folder, () =
       const frontYaml = yaml.safeLoad(yamlContents);
       assertPropTypes(videoFormat, frontYaml, "YAML", fileName);
     });
+
+    test('title matches internal numbering', () => {
+      // Get file name with leading zeros stripped
+      let fileNumber = fileName.split('-')[0];
+      fileNumber = fileNumber.replace(/^0+/, '');
+
+      let yamlContents = contents.split("---")[1];
+      const frontYaml = yaml.safeLoad(yamlContents);
+
+      // Gets internal representation as a string
+      let videoString = frontYaml.video_number.toString();
+      // If we're in a standalone
+      if(videoString === fileNumber) return;
+      // If the video has parts, check we match the last one only.
+      let parts = fileNumber.split('.');
+      if(videoString === parts[parts.length - 1]) return;
+      throw new Error('Expected file numbering to match internal numbering');
+    })
   }));
 });
 


### PR DESCRIPTION
Moves to PropTypes in order to check for keys that shouldn't exist but do. Sadly, this also implements a lot of the wonderful work of @MeaningOf42 and I am sorry about that.

Also, uses describe to label the tests as parts of testing a file for cleaner output.