### PR TITLE
CC_94_2048: Removed unnecessary direction in transposeGrid

### DIFF
--- a/CodingChallenges/CC_94_2048/grid.js
+++ b/CodingChallenges/CC_94_2048/grid.js
@@ -35,15 +35,11 @@ function flipGrid(grid) {
   return grid;
 }
 
-function transposeGrid(grid, direction) {
+function transposeGrid(grid) {
   let newGrid = blankGrid();
   for (let i = 0; i < 4; i++) {
     for (let j = 0; j < 4; j++) {
-      if (direction == 1) {
-        newGrid[i][j] = grid[j][i];
-      } else {
-        newGrid[j][i] = grid[i][j];
-      }
+      newGrid[i][j] = grid[j][i];
     }
   }
   return newGrid;

--- a/CodingChallenges/CC_94_2048/sketch.js
+++ b/CodingChallenges/CC_94_2048/sketch.js
@@ -29,11 +29,11 @@ function keyPressed() {
       flipped = true;
       break;
     case RIGHT_ARROW:
-      grid = transposeGrid(grid, 1);
+      grid = transposeGrid(grid);
       rotated = true;
       break;
     case LEFT_ARROW:
-      grid = transposeGrid(grid, 1);
+      grid = transposeGrid(grid);
       grid = flipGrid(grid);
       rotated = true;
       flipped = true;
@@ -52,7 +52,7 @@ function keyPressed() {
       grid = flipGrid(grid);
     }
     if (rotated) {
-      grid = transposeGrid(grid, -1);
+      grid = transposeGrid(grid);
     }
     if (changed) {
       addNumber();


### PR DESCRIPTION
I've removed the unnecessary `direction` argument from the `transposeGrid` function
because transposing a matrix is not dependent on a direction and this might be irritating.