### PR TITLE
Update 93-double-pendulum.md

### DIFF
--- a/_CodingChallenges/93-double-pendulum.md
+++ b/_CodingChallenges/93-double-pendulum.md
@@ -28,6 +28,12 @@ contributions:
       url: "http://codeblock.at/"
     url: "https://codepen.io/Grilly86/full/yvoVja"
     source: "https://codepen.io/Grilly86/pen/yvoVja"  
+  - title: "Double Pendulum with movable base and different integration algorithms"
+    author:
+      name: "Daniel Heinrich"
+      url: "https://hmbd.wordpress.com/2017/12/16/interactive-multibody-dynamics-in-processing/"
+    url: "https://www.openprocessing.org/sketch/507468"
+    source: "https://www.openprocessing.org/sketch/507468"  
 
 ---
 


### PR DESCRIPTION
https://www.openprocessing.org/sketch/507468

Written a few weeks ago and fits very nicely to the coding challenge. Especially it answers the question from your video why the order of speed and position integration matters (I'll also add a comment to the youtube video or somewhere else on this) --> it changes the integration mode from explicit euler (large integration error, accumulates energy) to symplectic euler (way better accuracy)...