### PR TITLE
Added my version of coding challange 90.

### DIFF
--- a/_CodingChallenges/90-floyd-steinberg-dithering.md
+++ b/_CodingChallenges/90-floyd-steinberg-dithering.md
@@ -21,7 +21,7 @@ videos:
   video_id: "EmtU0eloTlE"
 - title: "My Video on 2D Arrays"
   video_id: "OTNpiLUSiB4"  
-  
+
 contributions:
 - title: "Dither Kitty! Use your own image!"
   author:
@@ -29,6 +29,12 @@ contributions:
     url: "https://github.com/stellartux"
   url: "https://stellartux.github.io/CC90/"
   source: "https://github.com/stellartux/CC90"
+- title: "Image dithering in python that outputs to CSS"
+  author:
+    name: "MeaningOf42"
+    url: "github.com/MeaningOf42"
+  url: "meaningof42.github.io/pointless-site/css_dithering/index.html"
+  source: "github.com/MeaningOf42/pointless-site/tree/master/css_dithering"
 
 
 ---


### PR DESCRIPTION
My version of the challenge is written in python. As well as doing image dithering, it also makes a CSS file that can display the image without needing a HTML image tag. I'm not sure if I explained that very well, so I'll briefly show what my code does.

Checkout this page's source: [https://meaningof42.github.io/pointless-site/css_dithering/index.html](https://meaningof42.github.io/pointless-site/css_dithering/index.html)
Notice there is only a div tag in the html body. So how does the page display an image? Well CSS allows you to have an unlimited number of box shadows. Each pixel of the image is actually a box shadow of the first pixel which is the div element. Adding each box-shadow by hand would be infeasible, so I decided to write a python script to automatically convert an image into a collection of CSS box shadows. I decided that as I was creating this python script, I might as well dither the image before converting it to CSS to give it a stylized look.

Check out the source for more info: [https://github.com/MeaningOf42/pointless-site/tree/master/css_dithering](https://github.com/MeaningOf42/pointless-site/tree/master/css_dithering)