### PR TITLE
Add (existing) contribution to Coding Challenge 50 (website)

### DIFF
--- a/_CodingChallenges/50.1-circlepackinganimated.md
+++ b/_CodingChallenges/50.1-circlepackinganimated.md
@@ -16,6 +16,14 @@ links:
 parts:
 - title: "Animated Circle Packing - Part 2"
   url: "/CodingChallenges/50.2-circlepackingimage"
+
+contributions:
+  - title: "Fade out circles after time and use camera..."
+    author:
+      name: "romibi"
+      url: "https://github.com/romibi"
+    url: "https://github.com/romibi/Processing-Playground/raw/master/CC_50_2_CirclePackingImage/CC_50_2_CirclePackingImage.gif"
+    source: "https://github.com/romibi/Processing-Playground/tree/master/CC_50_2_CirclePackingImage"
 ---
 
 In this coding challenge, I demonstrate a circle packing algorithm and use it to fill the outline of a text path (in this case, this new year "2017") using Processing (Java).


### PR DESCRIPTION
Add my contribution to Coding Challenge 50 now also to the website md-files.
Do I see that correct that contributions here always should go to part 1?
See also PR #190 

Reminder: it was this:
#### By: [romibi](https://github.com/romibi) , [Repository](https://github.com/romibi/Processing-Playground/tree/master/CC_50_2_CirclePackingImage)  
![loading](https://github.com/romibi/Processing-Playground/raw/master/CC_50_2_CirclePackingImage/CC_50_2_CirclePackingImage.gif)  
Fade out circles after time and use camera...