### PR TITLE
CC 93 fix buffer dpi

### DIFF
--- a/CodingChallenges/CC_93_DoublePendulum_p5.js/sketch.js
+++ b/CodingChallenges/CC_93_DoublePendulum_p5.js/sketch.js
@@ -28,6 +28,8 @@ function setup() {
   cx = width / 2;
   cy = 50;
   buffer = createGraphics(width, height);
+  // correct buffer size for high DPI displays
+  buffer.pixelDensity(1);
   buffer.background(175);
   buffer.translate(cx, cy);
 }


### PR DESCRIPTION
This fixes issue https://github.com/CodingTrain/website/issues/574 - CC 93 (p5.js version)'s buffer size for high DPI screens. I tested it on Surface Pro 4 (175%).


