### PR TITLE
browser version of "2D Water Ripple"

### DIFF
--- a/_CodingChallenges/102-2d-water-ripple.md
+++ b/_CodingChallenges/102-2d-water-ripple.md
@@ -25,6 +25,11 @@ contributions:
     url: "https://codepen.io/Spongman/project/full/ArxVJQ/"
     source: "https://codepen.io/Spongman/project/editor/ArxVJQ"
 
+  - title: "Javascript 2D Water Ripple"
+    author:
+      name: "David Sarma"
+    url: "https://codepen.io/ds604/pen/VxroVN"
+    source: "https://gist.github.com/ds604/228483d2498cdfdf79ef9df22676b899"
 ---
 
 In this coding challenge, I attempt to simulate 2D water ripples using Processing (Java).


### PR DESCRIPTION
used 8 neighbors instead of 4, but otherwise same as Processing version (used to compare speed of canvas vs Processing)