### PR TITLE
Added a community example to circle packing

### DIFF
--- a/_CodingChallenges/050.1-circlepackinganimated.md
+++ b/_CodingChallenges/050.1-circlepackinganimated.md
@@ -25,6 +25,12 @@ contributions:
       url: "https://github.com/romibi"
     url: "https://github.com/romibi/Processing-Playground/blob/master/CC_050_2_CirclePackingImage/CC_050_2_CirclePackingImage.gif"
     source: "https://github.com/romibi/Processing-Playground/tree/master/CC_050_2_CirclePackingImage"
+  - title: "Alternative method (based on work by Paul Bourke), 2D or 3D display."
+    author:
+      name: "Ben (quillaja)"
+      url: "https://github.com/quillaja"
+    url: "http://www.quillaja.net/circ_pack/sketch.html"
+    source: "https://github.com/quillaja/p5-sketches/tree/master/circ_pack"
 ---
 
 In this coding challenge, I demonstrate a circle packing algorithm and use it to fill the outline of a text path (in this case, this new year "2017") using Processing (Java).


### PR DESCRIPTION
I implemented an alternative (but not necessarily better) method of circle packing based on a paper by Paul Bourke in which he describes using an infinite function that converges to the area of the space to be filled. I also added a number of bells and whistles in terms of displaying the result. Spacebar will toggle "2d" or "3d" mode--display as circles on a plane or spheres. Arrow keys rotate the result, "R" resets, and "P" toggles between orthographic and perspective perspectives.

Live demo: http://www.quillaja.net/circ_pack/sketch.html
Code: https://github.com/quillaja/p5-sketches/tree/master/circ_pack