### PR TITLE
Update sketch_11_10_BlobTracking_lifespan.pde

### DIFF
--- a/Tutorials/Processing/11_video/sketch_11_10_BlobTracking_lifespan/sketch_11_10_BlobTracking_lifespan.pde
+++ b/Tutorials/Processing/11_video/sketch_11_10_BlobTracking_lifespan/sketch_11_10_BlobTracking_lifespan.pde
@@ -145,7 +145,6 @@ void draw() {
       }
       if (matched != null) {
         matched.taken = true;
-        matched.lifespan = maxLife;
         matched.become(cb);
       }
     }

--- a/Tutorials/Processing/11_video/sketch_11_10_BlobTracking_lifespan/sketch_11_10_BlobTracking_lifespan.pde
+++ b/Tutorials/Processing/11_video/sketch_11_10_BlobTracking_lifespan/sketch_11_10_BlobTracking_lifespan.pde
@@ -145,6 +145,8 @@ void draw() {
       }
       if (matched != null) {
         matched.taken = true;
+        // Resetting the lifespan here is no longer necessary since setting `lifespan = maxLife;` in the become() method in Blob.pde
+        // matched.lifespan = maxLife;
         matched.become(cb);
       }
     }


### PR DESCRIPTION
setting lifespan here is redundant since setting `lifespan = maxLife;` in the `become()` function in Blob.pde
But it is probably for tutorial purpose 👍