### PR TITLE
Fix: CC93_p5 wrong rendering due DPI on a Mac

### DIFF
--- a/CodingChallenges/CC_093_DoublePendulum_p5.js/sketch.js
+++ b/CodingChallenges/CC_093_DoublePendulum_p5.js/sketch.js
@@ -23,6 +23,8 @@ let buffer;
 
 function setup() {
   createCanvas(500, 300);
+  //Issue with wrong rendering on a retina Mac. See Issue: https://github.com/CodingTrain/website/issues/574
+  pixelDensity(1);
   a1 = PI / 2;
   a2 = PI / 2;
   cx = width / 2;

--- a/CodingChallenges/CC_093_DoublePendulum_p5.js/sketch.js
+++ b/CodingChallenges/CC_093_DoublePendulum_p5.js/sketch.js
@@ -23,7 +23,7 @@ let buffer;
 
 function setup() {
   createCanvas(500, 300);
-  //Issue with wrong rendering on a retina Mac. See Issue: https://github.com/CodingTrain/website/issues/574
+  //Issue with wrong rendering on a retina Mac. See issue: https://github.com/CodingTrain/website/issues/574
   pixelDensity(1);
   a1 = PI / 2;
   a2 = PI / 2;


### PR DESCRIPTION
Issue with wrong rendering on a retina Mac. See issue: https://github.com/CodingTrain/website/issues/574