### PR TITLE
Removing the rest of the path array

### DIFF
--- a/CodingChallenges/CC_125_Fourier_Series/P5/sketch.js
+++ b/CodingChallenges/CC_125_Fourier_Series/P5/sketch.js
@@ -53,11 +53,6 @@ function draw() {
 
   time += 0.05;
 
-  if (time > TWO_PI) {
-    path = [];
-    time = 0;
-  }
-
   if (wave.length > 250) {
     wave.pop();
   }


### PR DESCRIPTION
In the livestream a path array was made to draw the path of the point.
This, however, was not included in the final video, therefore some unnecessary code for the path remained in the code.