### PR TITLE
Fix the error message output for when a video should be a local link

### DIFF
--- a/unit_testing/yaml.test.js
+++ b/unit_testing/yaml.test.js
@@ -152,7 +152,7 @@ const checkFolder = (videoFormat, name, { directories, files }) => describe(name
             if (k === 'video_id') {
               it(`linked video ID: ${videoId} is not a local link`, () => {
                 if (videoId in knownVideos) {
-                  throw new Error(`Video ${videoId} linked in ${file.path} should point to ${markdownFilenameToUrl(knownVideos[videoId].path)}`)
+                  throw new Error(`Video ${videoId} linked in ${file.path} should point to ${markdownFilenameToUrl(knownVideos[videoId][0].path)}`)
                 }
               })
             }


### PR DESCRIPTION
Fixes the issue just seen in #825 