### PR TITLE
Link doesn't work on mobile devices -fix

### DIFF
--- a/assets/css/2-base/_navigation.sass
+++ b/assets/css/2-base/_navigation.sass
@@ -36,7 +36,7 @@
     width: auto
 
   nav
-    width: 100%
+    width: 0%
     height: 5rem
     font-size: 16px
     overflow: hidden
@@ -115,6 +115,9 @@
       @media (max-width: $mobile)
         background: rgba(#FFF, 0.5)
 
+      nav
+        width: 100%
+        
       nav .links a
         @media (max-width: $mobile)
           visibility: visible


### PR DESCRIPTION
The culprit is the nav element just under .navigation  as talked about in #904  
This changes it's width to 0% unless the nav-toggle is checked, which hopefully solves the problem.
**Note:** I have no way of building and testing jekyll site, so hopefully I got the sass-code right.