### PR TITLE
Edit l.41 for digit count. Animation without using Pi

### DIFF
--- a/_CodingChallenges/139-pi-collisions.md
+++ b/_CodingChallenges/139-pi-collisions.md
@@ -18,6 +18,11 @@ contributions:
       url: "https://thecodingtrain.com"
     url: "https://github.com/CodingTrain/Pi-Day-2019"
     source: "https://github.com/CodingTrain/Pi-Day-2019"
+  - title: "Animation without using PI"
+    author:
+      name: "tht_jxny"
+    url: "https://editor.p5js.org/tht-jxny/full/RG9tqIJqN"
+    source: "https://editor.p5js.org/tht-jxny/sketches/RG9tqIJqN"
 
 links:
   - title: "Playing Pool with Pi"


### PR DESCRIPTION
https://editor.p5js.org/tht-jxny/full/RG9tqIJqN Fullscreen version for PI Collision Animation without using PI. To change number of digits modify line 41 to a mass thats a power of 100. I've created this animation before the CodingTrain Video came out based on 3Blue1Brown's video so its neither OOP nor can it deal with more than 4 digits (at least not my pc :D). To try more just reduce the initial velocity.