### PR TITLE
added example to CC 145-2d-ray-casting.md

### DIFF
--- a/_CodingChallenges/145-2d-ray-casting.md
+++ b/_CodingChallenges/145-2d-ray-casting.md
@@ -69,6 +69,12 @@ contributions:
       url: "https://github.com/nem0-97"
     url: "https://nem0-97.github.io/RayCasting/index.html"
     source: "https://github.com/nem0-97/RayCasting"
+  - title: "Wolfenstein 3D style raycasting with randomly generated mazes (p5.js)"
+    author:
+      name: "Ben (quillaja)"
+      url: "https://github.com/quillaja"
+    url: "http://www.quillaja.net/raymaze/sketch.html"
+    source: "https://github.com/quillaja/raymaze"
 videos:
   - title: "Coding Adventure: Ray Marching"
     author: "Sebastian Lague"


### PR DESCRIPTION
Added info for my example "wolfenstein 3d style raycasting with randomly generated mazes". This was inspired by a [video](https://www.youtube.com/watch?v=eOCQfxRQ2pY) by Matt Godbolt about how Wolfenstein 3D did raycasting in the ancient days.

keyboard arrow keys move player (also pressing at top, bottom, left, right of screen on touchscreen).
space toggles 3D/2D view, S toggles some statistics and viewing rays in the 2D view.