### PR TITLE
moved example from CC145 to CC146.

### DIFF
--- a/_CodingChallenges/145-2d-ray-casting.md
+++ b/_CodingChallenges/145-2d-ray-casting.md
@@ -69,12 +69,6 @@ contributions:
       url: "https://github.com/nem0-97"
     url: "https://nem0-97.github.io/RayCasting/index.html"
     source: "https://github.com/nem0-97/RayCasting"
-  - title: "Wolfenstein 3D style raycasting with randomly generated mazes (p5.js)"
-    author:
-      name: "Ben (quillaja)"
-      url: "https://github.com/quillaja"
-    url: "http://www.quillaja.net/raymaze/sketch.html"
-    source: "https://github.com/quillaja/raymaze"
 videos:
   - title: "Coding Adventure: Ray Marching"
     author: "Sebastian Lague"

--- a/_CodingChallenges/146-rendering-ray-casting.md
+++ b/_CodingChallenges/146-rendering-ray-casting.md
@@ -23,6 +23,12 @@ contributions:
       name: SolarLiner
       url: https://solarliner.me
     url: https://editor.p5js.org/SolarLiner/sketches/J1Y97pKuR
+  - title: "Wolfenstein 3D style raycasting with randomly generated mazes (p5.js)"
+    author:
+      name: "Ben (quillaja)"
+      url: "https://github.com/quillaja"
+    url: "http://www.quillaja.net/raymaze/sketch.html"
+    source: "https://github.com/quillaja/raymaze"
 ---
 
 Building off of the previous coding challenge (2D Ray Casting) I attempt to make my own version the original Wolfenstein 3D Raycasting engine and visualize the "field of view" of the moving particle.


### PR DESCRIPTION
CC 146 wasn't posted when I submitted my example to CC145, but is a much more appropriate match with CC146. See #1334 for the PR that originally added my example to C145. Sorry for the trouble.