### PR TITLE
Adding DHALF.txt as Community Reference for CC90

### DIFF
--- a/_CodingChallenges/090-floyd-steinberg-dithering.md
+++ b/_CodingChallenges/090-floyd-steinberg-dithering.md
@@ -43,6 +43,13 @@ contributions:
       url: "https://github.com/figraham"
     url: "https://github.com/figraham/exploringdithering"
     source: "https://github.com/figraham/exploringdithering"
+
+community_references:
+  - title: "DHALF.txt"
+    author:
+      name: "Fi Graham"
+      url: "http://createdby.fi"
+    url:  "https://github.com/SixLabors/ImageSharp/blob/master/src/ImageSharp/Processing/Processors/Dithering/DHALF.TXT"
 ---
 
 In this coding challenge, I attempt to implement the Floyd-Steinberg Dithering algorithm and create a "image stippling" effect on an image (kitten, of course) using Processing.


### PR DESCRIPTION
Link to DHALF.txt: [https://github.com/SixLabors/ImageSharp/blob/master/src/ImageSharp/Processing/Processors/Dithering/DHALF.TXT](https://github.com/SixLabors/ImageSharp/blob/master/src/ImageSharp/Processing/Processors/Dithering/DHALF.TXT)