### PR TITLE
Corrected mut function in Neural_Network.pde file

### DIFF
--- a/CodingChallenges/CC_100.1_NeuroEvolution_FlappyBird/Processing/CC_100_1_NeuroEvolution_FlappyBird/Neural_Network.pde
+++ b/CodingChallenges/CC_100.1_NeuroEvolution_FlappyBird/Processing/CC_100_1_NeuroEvolution_FlappyBird/Neural_Network.pde
@@ -66,7 +66,7 @@ class NeuralNetwork{
 
 
   float mut(float val, float rate){
-    if (random(1) > rate){
+    if (random(1) < rate){
       return val + randomGaussian() * .1;
     } else{
       return val;


### PR DESCRIPTION
Hello! I think there is a little error in 'mut' function of 'Neural_Network.pde' file in coding challenge 100. From my knowledge the if condition on line 69 should be:

`if(random(1) < rate)`
instead of:
`if(random(1) > rate)`

Suppose the rate is 0.9, then what our intention is to mutate 90% of the time. But according to me, the function is performing other way round right now i.e the probability that the random(1) > 0.9 is just 10%.
Also when I checked the P5 version of this coding challenge, I found the 'mutate' function correct there.
Here are the snippets from both the versions.
This snippet is from P5 version which I think is correct:

![image](https://user-images.githubusercontent.com/40419750/59094075-0020d580-8933-11e9-985c-d9dd6fd95adb.png)
 

And this is from Processing version:

![image](https://user-images.githubusercontent.com/40419750/59094136-247cb200-8933-11e9-9f88-dc15630c1cea.png)
 


Correct me if I'm missing something here.
Cheers! 
   