### PR TITLE
Fixing issue on CC_098.3_QuadTree_Collisions not working properly if …

### DIFF
--- a/CodingChallenges/CC_098.3_QuadTree_Collisions/Processing/CC_098.3_QuadTree_Collisions/Rectangle.pde
+++ b/CodingChallenges/CC_098.3_QuadTree_Collisions/Processing/CC_098.3_QuadTree_Collisions/Rectangle.pde
@@ -16,11 +16,11 @@ class Rectangle {
  double height ; 
  double width;
  
- public Rectangle (double x , double y , double height , double width){
+ public Rectangle (double x , double y , double width , double height){
    this.x = x;
    this.y = y;
-   this.height = height;
    this.width = width;
+   this.height = height;
  }
   public boolean intersects(Rectangle range) {
     return !(range.x - range.width> this.x + this.width||


### PR DESCRIPTION
…canvas size is not square

Class QuadTree was passing (width, height) to the Rectangle constructor and the Rectangle was using it inversed as (height, width).
Basically, QuadTree was asking for ▭ and the Rectangle was doing ▯.

This will fix the issue: https://github.com/CodingTrain/website/issues/1587