### PR TITLE
fixed broken video id in CC145

### DIFF
--- a/_CodingChallenges/145-2d-ray-casting.md
+++ b/_CodingChallenges/145-2d-ray-casting.md
@@ -136,7 +136,7 @@ videos:
     video_id: "uSzGdfdOoG8"
   - title: "Coding Challenge: Rendering Ray Casting"
     author: "Coding Train"
-    url: "/CodingChallenges/146-rendering-ray-casting"
+    video_id: "vYgIKn7iDH8"
 ---
 
 In this video, I implement a basic ray casting engine with line segment "surfaces" and vector "rays." The result simulates a light source casting shadows in a 2D canvas.


### PR DESCRIPTION
@violetcraze thank you for catching this error and attempting to fix it but this is the actual fix we would need because we want to link to youtube video not the coding challenge page. Am I right @shiffman?