### PR TITLE
add link to mentioned video in CC26

### DIFF
--- a/_CodingChallenges/026-supershape3d.md
+++ b/_CodingChallenges/026-supershape3d.md
@@ -17,6 +17,11 @@ links:
   - title: "Peasycam"
     url: "http://mrfeinberg.com/peasycam/"
     author: Jonathan Feinberg
+videos:
+  - title: "Coding Challenge: Spherical Geometry"
+    author: "The Coding Train"
+    url: "/CodingChallenges/025-spheregeometry"
+  
 contributions:
   - title: "3D SuperShape in WEBGL"
     author:

--- a/_CodingChallenges/026-supershape3d.md
+++ b/_CodingChallenges/026-supershape3d.md
@@ -21,7 +21,6 @@ videos:
   - title: "Coding Challenge: Spherical Geometry"
     author: "The Coding Train"
     url: "/CodingChallenges/025-spheregeometry"
-  
 contributions:
   - title: "3D SuperShape in WEBGL"
     author:


### PR DESCRIPTION
I noticed that the spherical geometry video wasn't linked to on the supershape challenge page even though its mentioned in the video so I added it