### PR TITLE
Fix: invalid `letter-spacing` unit

### DIFF
--- a/assets/css/1-tools/_vars.sass
+++ b/assets/css/1-tools/_vars.sass
@@ -13,7 +13,7 @@ $body-text-letter-spacing: 0.02em
 $body-text-line-height: 1.4
 
 $title-text: 'cubanoregular'
-$title-text-letter-spacing: .4
+$title-text-letter-spacing: .4px
 
 
 // Coding Train Colors


### PR DESCRIPTION
I guess `letter-spacing` without px unit is invalid.

![letter-spacing-ct-ff](https://user-images.githubusercontent.com/35374649/67139058-4aaf4880-f269-11e9-8523-80065164f9f9.PNG)
![letter-spacing-ct](https://user-images.githubusercontent.com/35374649/67139059-4aaf4880-f269-11e9-8e4d-b9d453f5875a.PNG)