### PR TITLE
Update breakpoint for nav bar

### DIFF
--- a/assets/css/2-base/_navigation.sass
+++ b/assets/css/2-base/_navigation.sass
@@ -15,7 +15,7 @@
   top: 20px
   z-index: 10000
 
-  @media (max-width: $mobile)
+  @media (max-width: $tablet-big)
     display: flex
     cursor: pointer
 
@@ -36,7 +36,7 @@
   width: 100%
   z-index: 9000
 
-  @media (max-width: $mobile)
+  @media (max-width: $tablet-big)
     padding-top: 2rem
     width: auto
 
@@ -47,7 +47,7 @@
     overflow: hidden
     background: rgba(9,20,154,0.55)
 
-    @media (max-width: $mobile)
+    @media (max-width: $tablet-big)
       width: 0%
       height: auto
       top: 10rem
@@ -62,7 +62,7 @@
       justify-content: center
       align-items: center
 
-      @media (max-width: $mobile)
+      @media (max-width: $tablet-big)
         flex-direction: column
         align-items: flex-start
         height: auto
@@ -85,7 +85,7 @@
           border-color: $white
           text-shadow: 0px 0px 5px #BBB
 
-        @media (max-width: $mobile)
+        @media (max-width: $tablet-big)
           visibility: hidden
           margin: 0.5em 0
           text-shadow: none
@@ -112,7 +112,7 @@
 
 #menu-button
   ~ .mobilenav-backdrop.active
-    @media (max-width: $mobile)
+    @media (max-width: $tablet-big)
       filter: blur(10px)
       pointer-events: none
 
@@ -120,7 +120,7 @@
     transform: translateX(20%)
 
   ~ .navigation.active
-    @media (max-width: $mobile)
+    @media (max-width: $tablet-big)
       background: rgba(#FFF, 0.5)
       position: fixed
       top: 0
@@ -131,7 +131,7 @@
       width: 100%
 
     nav .links li
-      @media (max-width: $mobile)
+      @media (max-width: $tablet-big)
         a
           visibility: visible
           opacity: 1


### PR DESCRIPTION
As mentioned in Issue #1834 

$mobile breakpoint was not sufficient to stop the nav bar overflowing. Have updated to $tablet-big(:920px) for sufficient space (as of current nav layout).