### PR TITLE
Fixed format for CC 097.2-book-of-pi.md

### DIFF
--- a/_CodingChallenges/097.2-book-of-pi.md
+++ b/_CodingChallenges/097.2-book-of-pi.md
@@ -25,7 +25,7 @@ videos:
 parts:
   - title: "The Book of Pi - Part 1"
     url: "/CodingChallenges/097.1-book-of-pi"
-  ---
+---
 
 In this Pi Day themed coding challenge, I use Processing (Java) to export a pdf of the first 10 million digits of Pi.
 


### PR DESCRIPTION
I found an extra space in `097.2-book-of-pi.md` which caused this [subpage](https://thecodingtrain.com/CodingChallenges/097.2-book-of-pi) not to build. Probably the testing should be extended so that such an error does not recur.