### PR TITLE
rearranged footer links

### DIFF
--- a/_jekyll/includes/2-base/footer.html
+++ b/_jekyll/includes/2-base/footer.html
@@ -4,8 +4,8 @@ This file will be included after every page.
 
 <footer>
   <div class="links">
+    <a href="http://shiffman.net/" class="shiffman-net"><span>shiffman.net</span></a>
     <a href="http://natureofcode.com" class="nature-of-code"><span>Nature of Code</span></a>
     <a href="http://learningprocessing.com/" class="learning-processing"><span>Learning Processing</span></a>
-    <a href="http://shiffman.net/" class="shiffman-net"><span>shiffman.net</span></a>
   </div>
 </footer>


### PR DESCRIPTION
Since the new `back to top` has the same background color as the `shiffman.net` footer link I moved it from the far right to the far left, I don't if this is the best solution but it is the easiest.

Before ![Before](https://user-images.githubusercontent.com/45735850/68143928-805a5f80-ff00-11e9-9837-c7785f77de84.jpg)


After ![After](https://user-images.githubusercontent.com/45735850/68143949-88b29a80-ff00-11e9-8d89-a8fe0489d360.jpg)


Full footer after ![full after](https://user-images.githubusercontent.com/45735850/68143956-8f411200-ff00-11e9-9908-fe1cab203ebd.jpg)
