### PR TITLE
Add Teachable Machine videos to landing page #1901

### DIFF
--- a/_TeachableMachine/2-teachable-game.md
+++ b/_TeachableMachine/2-teachable-game.md
@@ -1,7 +1,7 @@
 ---
 title: "Teachable Machine: Snake"
 video_number: 2
-date: 2019-11-07
+date: 2019-11-08
 video_id: UPgxnGC8oBU
 repository: 2-teachable-game
 web_editor: tqoOkW_ai

--- a/_TeachableMachine/3-teachable-audio.md
+++ b/_TeachableMachine/3-teachable-audio.md
@@ -1,7 +1,7 @@
 ---
 title: "Teachable Machine: Audio"
 video_number: 3
-date: 2019-11-07
+date: 2019-11-11
 video_id: TOrVsLklltM
 repository: 3-teachable-audio
 web_editor: e3nrNMG7A

--- a/_TeachableMachine/index.md
+++ b/_TeachableMachine/index.md
@@ -13,6 +13,6 @@ redirect_from:
 <div class="add-bars">
   <p>
     Introducing <a href="https://teachablemachine.withgoogle.com/">Teachable Machine 2.0 from Google Creative Lab</a>! <br/>
-    Train a computer to recognize your own images, sounds, & poses.
+    Train a computer to recognize your own images, sounds & poses.
   </p>
 </div>

--- a/landing-page.html
+++ b/landing-page.html
@@ -8,8 +8,8 @@ permalink: /
 {% assign nextStream = out_sortedVideos | where_exp: 'stream', 'stream.date >= site.time' | first %}
 
 {% comment %} Get latest coding challenges, coding in the cabana and teachable machine video. {% endcomment %}
-{% assign ChallengeCabanaTMVideos = site.CodingInTheCabana | concat: site.CodingChallenges | concat: site.TeachableMachine %}
-{% include 1-tools/sort-videos.html videos=ChallengeCabanaTMVideos sortByDate=true reverse=true %}
+{% assign featuredSeries = site.CodingInTheCabana | concat: site.CodingChallenges | concat: site.TeachableMachine %}
+{% include 1-tools/sort-videos.html videos=featuredSeries sortByDate=true reverse=true %}
 
 {% comment %} Use the latest coding challenge, coding in the cabana or teachable machine video if a stream hasn't been scheduled yet. {% endcomment %}
 {% if nextStream == null %}

--- a/landing-page.html
+++ b/landing-page.html
@@ -7,11 +7,11 @@ permalink: /
 {% include 1-tools/sort-videos.html videos=site.Streams future=true reverse=true %}
 {% assign nextStream = out_sortedVideos | where_exp: 'stream', 'stream.date >= site.time' | first %}
 
-{% comment %} Get latest coding challenges and coding in the cabana. {% endcomment %}
-{% assign CabanaAndChallengeVideos = site.CodingInTheCabana | concat: site.CodingChallenges %}
-{% include 1-tools/sort-videos.html videos=CabanaAndChallengeVideos sortByDate=true reverse=true %}
+{% comment %} Get latest coding challenges, coding in the cabana and teachable machine video. {% endcomment %}
+{% assign ChallengeCabanaTMVideos = site.CodingInTheCabana | concat: site.CodingChallenges | concat: site.TeachableMachine %}
+{% include 1-tools/sort-videos.html videos=ChallengeCabanaTMVideos sortByDate=true reverse=true %}
 
-{% comment %} Use the latest coding challenge or coding in the cabana if a stream hasn't been scheduled yet. {% endcomment %}
+{% comment %} Use the latest coding challenge, coding in the cabana or teachable machine video if a stream hasn't been scheduled yet. {% endcomment %}
 {% if nextStream == null %}
   {% assign offset = 1 %}
   {% assign nextStream = out_sortedVideos | first %}
@@ -21,9 +21,9 @@ permalink: /
 
 {% assign featuredVideos = '' | split: '' %}
 
-{% comment %} Add latest coding challenges or coding in the cabana to featured videos array. {% endcomment %}
-{% for challengeOrCabana in out_sortedVideos limit:2 offset:offset %}
-  {% assign featuredVideos = featuredVideos | push: challengeOrCabana %}
+{% comment %} Add latest coding challenges, coding in the cabana or teachable machine video to featured videos array. {% endcomment %}
+{% for challengeCabanaOrTM in out_sortedVideos limit:2 offset:offset %}
+  {% assign featuredVideos = featuredVideos | push: challengeCabanaOrTM %}
 {% endfor %}
 
 {% comment %} Get lastest stream and add it to the featured videos array. {% endcomment %}


### PR DESCRIPTION
As suggested in #1901 I added the Teachable Machine videos to the landing page and fixed the release dates for them to appear in the right order.

![image](https://user-images.githubusercontent.com/20423069/68535742-a8eeb900-0347-11ea-8a7b-bacc8afd5b72.png)