### PR TITLE
Add highlight for links to guest tutorials and Teachable Machine videos

### DIFF
--- a/_Tutorials/index.md
+++ b/_Tutorials/index.md
@@ -5,6 +5,6 @@ layout: series-index
 
 Here you can find all tutorials made by Daniel Shiffman on TheCodingTrain.
 
-If you are searching for tutorials made by guests, you can check them out [here]({{ site.baseurl }}{% link _GuestTutorials/index.md %}).
+If you are searching for tutorials made by <highlight>guests</highlight>, you can check them out [here]({{ site.baseurl }}{% link _GuestTutorials/index.md %}).
 
-If you are looking for the Teachable Machine videos they are available [here]({{ site.baseurl }}{% link _TeachableMachine/index.md %}).
+If you are looking for the <highlight>Teachable Machine</highlight> videos they are available [here]({{ site.baseurl }}{% link _TeachableMachine/index.md %}).

--- a/assets/css/2-base/_typeface.sass
+++ b/assets/css/2-base/_typeface.sass
@@ -38,5 +38,5 @@ h3
   font-size: 1.8rem
 
 highlight
-  color: $ct-green
+  color: $ct-blue
   font-weight: bold

--- a/assets/css/2-base/_typeface.sass
+++ b/assets/css/2-base/_typeface.sass
@@ -36,3 +36,7 @@ h3
   margin: -1.25em 0em 2em
   @include text-style('title')
   font-size: 1.8rem
+
+highlight
+  color: $ct-green
+  font-weight: bold


### PR DESCRIPTION
I think it is easy to overlook the links to the guest tutorials and the Teachable Machine videos, so I highlighted "guests" and "Teachable Machine":

![image](https://user-images.githubusercontent.com/20423069/68536146-5cf34280-034e-11ea-964c-919247acafb8.png)

