### PR TITLE
Removing Label Line in Pull Request Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@ Thank you for contributing to The Coding Train website!
 
 This is a template to get more information about your pull request. To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the preview tab! Feel free to remove all or any portion of the template that is not relevant, as it is mainly designed for community contributions.
 
-It would be helpful if in the sidebar on the right of your screen you could add "Community Contribution" using the "Labels" menu. You can see the guide at: https://thecodingtrain.com/Guides/community-contribution-guide.html.
+You can see the guide at: https://thecodingtrain.com/Guides/community-contribution-guide.html.
 -->
 
 ### Community Contribution


### PR DESCRIPTION
In #1902 it was pointed out that the labels are only available to maintainers so removing the line about it in the template. Sorry that was my bad I just assumed it was visible to everyone.