### PR TITLE
Fix links to repo in ml5-beginners-guide

### DIFF
--- a/_Courses/ml5-beginners-guide/1.1-ml5-image-classification.md
+++ b/_Courses/ml5-beginners-guide/1.1-ml5-image-classification.md
@@ -3,7 +3,7 @@ title: "ml5.js: Image Classification with MobileNet"
 video_number: 1.1
 date: 2018-08-01
 video_id: yNkAuWz5lnY
-repository: https://github.com/CodingTrain/website/tree/master/Courses/beginner_ml5/02_image_classification
+repository: beginner_ml5/02_image_classification
 can_contribute: true
 ignore_filename: true
 

--- a/_Courses/ml5-beginners-guide/1.2-ml5-webcam-image-classification.md
+++ b/_Courses/ml5-beginners-guide/1.2-ml5-webcam-image-classification.md
@@ -3,7 +3,7 @@ title: "ml5.js: Webcam Image Classification"
 video_number: 1.2
 date: 2018-08-02
 video_id: D9BoBSkLvFo
-repository: https://github.com/CodingTrain/website/tree/master/Courses/beginner_ml5/03_video_classification
+repository: beginner_ml5/03_video_classification
 can_contribute: true
 ignore_filename: true
 

--- a/_Courses/ml5-beginners-guide/3.1-ml5-feature-extractor-classification.md
+++ b/_Courses/ml5-beginners-guide/3.1-ml5-feature-extractor-classification.md
@@ -3,7 +3,7 @@ title: "ml5.js: Feature Extractor Classification"
 video_number: 3.1
 date: 2018-08-14
 video_id: eeO-rWYFuG0
-repository: https://github.com/CodingTrain/website/tree/master/Courses/beginner_ml5/04_feature_extractor_classification
+repository: beginner_ml5/04_feature_extractor_classification
 can_contribute: true
 ignore_filename: true
 

--- a/_Courses/ml5-beginners-guide/3.2-ml5-feature-extractor-regression.md
+++ b/_Courses/ml5-beginners-guide/3.2-ml5-feature-extractor-regression.md
@@ -3,7 +3,7 @@ title: "ml5.js: Feature Extractor Regression"
 video_number: 3.2
 date: 2018-08-16
 video_id: aKgq0m1YjvQ
-repository: https://github.com/CodingTrain/website/tree/master/Courses/beginner_ml5/05_feature_extractor_regression
+repository: beginner_ml5/05_feature_extractor_regression
 can_contribute: true
 ignore_filename: true
 

--- a/_Courses/ml5-beginners-guide/4.1-ml5-save-load-model.md
+++ b/_Courses/ml5-beginners-guide/4.1-ml5-save-load-model.md
@@ -3,7 +3,7 @@ title: "ml5.js: Save/Load Model"
 video_number: 4.1
 date: 2018-11-12
 video_id: eU7gIy3xV30
-repository: https://github.com/CodingTrain/website/tree/master/Courses/beginner_ml5/06_feature_extractor_load_save
+repository: beginner_ml5/06_feature_extractor_load_save
 can_contribute: true
 ignore_filename: true
 

--- a/_Courses/ml5-beginners-guide/5.1-ml5-knn-classification-1.md
+++ b/_Courses/ml5-beginners-guide/5.1-ml5-knn-classification-1.md
@@ -3,7 +3,7 @@ title: "ml5.js: KNN Classification Part 1"
 video_number: 5.1
 date: 2019-02-04
 video_id: KTNqXwkLuM4
-repository: https://github.com/CodingTrain/website/tree/master/Courses/beginner_ml5/07_knn_classifier
+repository: beginner_ml5/07_knn_classifier
 can_contribute: true
 ignore_filename: true
 

--- a/_Courses/ml5-beginners-guide/5.2-ml5-knn-classification-2.md
+++ b/_Courses/ml5-beginners-guide/5.2-ml5-knn-classification-2.md
@@ -3,7 +3,7 @@ title: "ml5.js: KNN Classification Part 2"
 video_number: 5.2
 date: 2019-02-04
 video_id: Mwo5_bUVhlA
-repository: https://github.com/CodingTrain/website/tree/master/Courses/beginner_ml5/07_knn_classifier
+repository: beginner_ml5/07_knn_classifier
 can_contribute: true
 ignore_filename: true
 

--- a/_Courses/ml5-beginners-guide/5.3-ml5-knn-classification-3.md
+++ b/_Courses/ml5-beginners-guide/5.3-ml5-knn-classification-3.md
@@ -3,7 +3,7 @@ title: "ml5.js: KNN Classification Part 3"
 video_number: 5.3
 date: 2019-02-07
 video_id: JWsKay58Z2g
-repository: https://github.com/CodingTrain/website/tree/master/Courses/beginner_ml5/07_knn_classifier
+repository: beginner_ml5/07_knn_classifier
 can_contribute: true
 ignore_filename: true
 


### PR DESCRIPTION
Some `.md` files in the "ml5-beginners-guide" course linked to the repo on github.com which caused the buttons "Download Code" and "Live Demo" not to show up. 

<img width="565" alt="changes" src="https://user-images.githubusercontent.com/20423069/69977533-44c8aa80-152b-11ea-8d78-b4988194550d.png">
