### PR TITLE
Add build command for linux to guide

### DIFF
--- a/_Guides/core-contribution-guide.md
+++ b/_Guides/core-contribution-guide.md
@@ -30,6 +30,10 @@ After that, simply run
 ```
 $ docker-compose up
 ```
+Linux users may have to use `sudo` to build the site. It is a minor change to the original command, simply run
+```
+$ sudo docker-compose up
+```
 
 Docker will then run a container with all dependencies installed.
 Head over to `http://localhost:4000` to see the built site.


### PR DESCRIPTION
When i tried to build the website on linux I had to use `sudo` so I though i would add that to the guide