### PR TITLE
Contribute a variant of the Hilbert Curve sketch

### DIFF
--- a/_CodingInTheCabana/003-hilbert-curve.md
+++ b/_CodingInTheCabana/003-hilbert-curve.md
@@ -32,5 +32,11 @@ contributions:
       url: "https://editor.p5js.org/KobeL/sketches"
     url: "https://editor.p5js.org/KobeL/full/LqyM45kZ"
     source: "https://editor.p5js.org/KobeL/sketches/LqyM45kZ"
+  - title: "Hilbert Curve that zooms out from one order to the next"
+    author:
+      name: "Frode Austvik"
+      url: "https://github.com/edorfaus"
+    url: "https://edorfaus.github.io/coding-train-variants/CodingInTheCabana/Cabana_003_Hilbert_Curve/P5/"
+    source: "https://github.com/edorfaus/coding-train-variants/tree/master/CodingInTheCabana/Cabana_003_Hilbert_Curve/P5"
 ---
 It's the third episode of Coding in the Cabana! On this snowy day, I attempt to animate the path of the classic "space filling curve" known as the Hilbert Curve.


### PR DESCRIPTION
### Community Contribution

**Link to live project, video, or image:**
https://edorfaus.github.io/coding-train-variants/CodingInTheCabana/Cabana_003_Hilbert_Curve/P5/

This variant starts by drawing an order-1 Hilbert Curve, then zooms out and keeps going, until it fills the entire canvas. To make the direction the curve is displayed in consistent, and the zooming easier, the sketch draws the curve in two directions simultaneously (at different speeds), starting from the bottom-left corner of the curve.

The code has some visualization control parameters at the top, but there's currently no UI for changing them.

### Sharing

- [ ] I would be happy to have my project shared on The Coding Train's social media!

-- It would be more of a shrug - I guess I don't mind if you really _want_ to share it, but it's not something I particularly care about (since I tend to avoid social media), so it wouldn't make me be happy.