### PR TITLE
Update overview link for contributing ports

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Here are the type of contributions we are looking for:
  - adding a link to your creative version of a challenge or tutorial - [guide](https://thecodingtrain.com/Guides/community-contribution-guide.html)
  - website design improvements
  - adding any missing content - [guide](https://thecodingtrain.com/Guides/content-contribution-guide.html)
- - porting coding challenges to other languages (eg. Processing -> JavaScript/p5.js) - [overview](https://gist.github.com/gruselhaus/368d87bf4e3558f01292e8c00afda224)
+ - porting coding challenges to other languages (eg. Processing -> JavaScript/p5.js) - [overview](https://github.com/CodingTrain/website/issues/1347)
 
 The code in the repository should match the code written in the YouTube tutorials, so that fellow passengers can use this code as a base for their own implementations.
 


### PR DESCRIPTION
The old link doesn't work (404), so update it to point to the pinned issue for porting, since that contains an overview table that it says is updated automatically.