### PR TITLE
removed the flipped Video after classification

### DIFF
--- a/TeachableMachine/2-teachable-game/P5/sketch.js
+++ b/TeachableMachine/2-teachable-game/P5/sketch.js
@@ -32,7 +32,7 @@ function setup() {
   video = createCapture(VIDEO);
   video.size(640, 480);
   video.hide();
-  // Mirro the video since we trained it that way!
+  // Mirror the video since we trained it that way!
   flipVideo = ml5.flipImage(video);
 
   // STEP 2: Start classifying
@@ -51,6 +51,7 @@ function classifyVideo() {
   // Flip the video!
   flipVideo = ml5.flipImage(video);
   classifier.classify(flipVideo, gotResults);
+  flipVideo.remove()
 }
 
 // Snake Game


### PR DESCRIPTION
If the video is not removed, it causes new <canvas> elements to be added to the DOM constantly , this could cause a huge spike in memory usage

<!--
Thank you for contributing to The Coding Train website!

This is a template to get more information about your pull request. To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the preview tab! Feel free to remove all or any portion of the template that is not relevant, as it is mainly designed for community contributions.

You can see the guide at: https://thecodingtrain.com/Guides/community-contribution-guide.html.
-->

This is just a quick bugfix


