### PR TITLE
Remove an incorrect web editor link.

### DIFF
--- a/CodingChallenges/CC_141_Mandelbrot_Pi/Processing/CC_141_Mandelbrot_Pi/CC_141_Mandelbrot_Pi.pde
+++ b/CodingChallenges/CC_141_Mandelbrot_Pi/Processing/CC_141_Mandelbrot_Pi/CC_141_Mandelbrot_Pi.pde
@@ -2,7 +2,6 @@
 // Daniel Shiffman
 // https://thecodingtrain.com/CodingChallenges/141-mandelbrot-pi.html
 // https://youtu.be/pn2vlselv_g
-// https://editor.p5js.org/codingtrain/sketches/LbNt1nyxE
 
 import java.math.BigDecimal;
 import java.math.BigInteger;


### PR DESCRIPTION
It points to the sketch from an earlier coding challenge (CC 138: Angry Bird), and since there's no p5.js version of this challenge (yet), there isn't any correct link to replace it with.