### PR TITLE
Fix a bug in CC_010_Maze_DFS

### DIFF
--- a/CodingChallenges/CC_010_Maze_DFS/P5/sketch.js
+++ b/CodingChallenges/CC_010_Maze_DFS/P5/sketch.js
@@ -68,18 +68,18 @@ function index(i, j) {
 
 function removeWalls(a, b) {
   let x = a.i - b.i;
-  if (x === 1) {
+  let y = a.j - b.j;
+
+  if (x === 1 && y === 0) {
     a.walls[3] = false;
     b.walls[1] = false;
-  } else if (x === -1) {
+  } else if (x === -1 && y === 0) {
     a.walls[1] = false;
     b.walls[3] = false;
-  }
-  let y = a.j - b.j;
-  if (y === 1) {
+  } else if (y === 1 && x === 0) {
     a.walls[0] = false;
     b.walls[2] = false;
-  } else if (y === -1) {
+  } else if (y === -1 && x === 0) {
     a.walls[2] = false;
     b.walls[0] = false;
   }


### PR DESCRIPTION
It fixes a bug, when a and b are not neighbors.
If a and b are "diagonal" neighbors, then walls still would be broken.

<!--
Thank you for contributing to The Coding Train website!

This is a template to get more information about your pull request. To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the preview tab! Feel free to remove all or any portion of the template that is not relevant, as it is mainly designed for community contributions.

You can see the guide at: https://thecodingtrain.com/Guides/community-contribution-guide.html.
-->

### Community Contribution

**Link to live project, video, or image:**
https://github.com/tigertv

### Sharing

- [x] I would be happy to have my project shared on The Coding Train's social media!

<!-- If you would like us to tag you in any posts about your work please include your handle below. -->
