### PR TITLE
Fixing Web Editor API

### DIFF
--- a/_learning/nature-of-code/2.2-mass-acceleration.md
+++ b/_learning/nature-of-code/2.2-mass-acceleration.md
@@ -12,7 +12,7 @@ links:
     url: https://en.wikipedia.org/wiki/Galileo%27s_Leaning_Tower_of_Pisa_experiment
   - title: "Newton's Laws of Motion (Wikipedia)"
     url: https://en.wikipedia.org/wiki/Newton%27s_laws_of_motion
-    
+
 videos:
   - title: "Static Functions - The Nature of Code"
     author: "The Coding Train"

--- a/unit_testing/yaml.test.js
+++ b/unit_testing/yaml.test.js
@@ -291,7 +291,7 @@ describe('Web Editors', () => {
         let webEditorData;
 
         beforeAll(async () => {
-          const resp = await fetch(`https://editor.p5js.org/api/projects/${web_editor}`);
+          const resp = await fetch(`https://editor.p5js.org/editor/projects/${web_editor}`);
           webEditorData = await resp.json();
         });
 


### PR DESCRIPTION
fixes #2199 

They switched the api path to /editor from /api for most routes. More here: https://github.com/processing/p5.js-web-editor/pull/1106