### PR TITLE
Worley Noise: adding extra code examples in separate repo

### DIFF
--- a/_CodingInTheCabana/004-worley-noise.md
+++ b/_CodingInTheCabana/004-worley-noise.md
@@ -7,6 +7,8 @@ web_editor: QsiCWVczZ
 repository: Cabana_004_worley_noise
 
 links:
+  - title: "Additional code examples for video visuals"
+    url: https://github.com/CodingTrain/WorleyNoise
   - title: "Worley noise (Wikipedia)"
     url: https://en.wikipedia.org/wiki/Worley_noise
   - title: "A Cellular Texture Basis Function"


### PR DESCRIPTION
Eventually these should probably make their way here but for now I am just going to link to the other repo so I can work on cleaning up and commenting the extra examples. 