### PR TITLE
Fixing Download Code

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,7 @@ baseurl: /
 repository: CodingTrain/website
 
 # Prefix for download links (downloads only the relevant code from GitHub).
-github_download_prefix: https://minhaskamal.github.io/DownGit/#/home?url=
+github_download_prefix: https://codingtrain.github.io/DownGit/#/home?url=
 
 # Prefixes for editor.p5js.org
 web_editor_sketch_prefix: https://editor.p5js.org/codingtrain/sketches/


### PR DESCRIPTION
Forked DownGit and added regex to only allow files from this repository. Fixes #2178 

New DownGit for CodingTrain: https://github.com/CodingTrain/DownGit
More about changes: https://github.com/CodingTrain/DownGit/pull/1