### PR TITLE
Data for SEO for easier sharing and being searched

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ source "https://rubygems.org"
 # If you have any plugins, put them here!
 group :jekyll_plugins do
   gem "github-pages"
+  gem 'jekyll-seo-tag'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -261,6 +261,7 @@ DEPENDENCIES
   dotenv
   github-pages
   html-proofer
+  jekyll-seo-tag
   tzinfo-data
 
 BUNDLED WITH

--- a/_config.yml
+++ b/_config.yml
@@ -58,6 +58,10 @@ links:
   # Link to the Amazon store.
   amazon: https://www.amazon.com/shop/thecodingtrain
 
+# SEO data for twitter
+twitter:
+  username: thecodingtrain
+
 # --- Build Settings ---
 
 # Use Kramdown as the preferred Markdown parser.
@@ -91,6 +95,7 @@ sass: { sass_dir: "assets/css" }
 # Use jekyll-redirect-from to allow redirections
 plugins:
   - jekyll-redirect-from
+  - jekyll-seo-tag
 
 # --- Jekyll Locations ---
 layouts_dir: _jekyll/layouts

--- a/_jekyll/includes/2-base/head.html
+++ b/_jekyll/includes/2-base/head.html
@@ -56,3 +56,8 @@ the tracking result.
 <script src="https://www.youtube.com/iframe_api"></script>
 <script src="{{ '/assets/javascript/functions.js' | relative_url }}"></script>
 <script type="text/javascript" src="https://unpkg.com/smoothscroll-polyfill@0.4.4/dist/smoothscroll.js"></script>
+
+{% comment %}
+Data for SEO for easier sharing and being searched
+{% endcomment %}
+{% seo %}


### PR DESCRIPTION
Adding a plugin for jekyll so that when a page link is shared, it has better information, on different social networks and communication channels

Add images of what it will look like from, using my page fork as an example. I leave related link

## Plugin Jekyll

https://github.com/jekyll/jekyll-seo-tag

## Test tool

https://developers.facebook.com/tools/debug
https://cards-dev.twitter.com/validator

## Link test

https://thecodingtrain.com/CodingChallenges/152-rdp-algorithm.html
https://nocheprogramacion.com/Tutoriales/064_Como_usar_Discord_Paso_a_Paso.html

### Test Twitter

![Image of Twitter](https://i.imgur.com/HsVbXBe.png)

### Test Discord

![Image of Discord](https://i.imgur.com/ZhdZpaY.png)

### Test Telegram

![Image of Telegram](https://i.imgur.com/fzttRdS.png)


discuss my english

### Sharing

**Instagram:** ALSWnet

**Twitter:** ALSWnet

**Youtube:** ALSWnet
