### PR TITLE
Small fix in cave generation with marching squares

### DIFF
--- a/challenges/coding-in-the-cabana/005_marching_squares/P5_cave/sketch.js
+++ b/challenges/coding-in-the-cabana/005_marching_squares/P5_cave/sketch.js
@@ -95,7 +95,7 @@ function countNeighbors(x, y) {
   for (let i = x - 1; i <= x + 1; i++) {
     for (let j = y - 1; j <= y + 1; j++) {
       if (i >= 0 && i < rows && j >= 0 && j < cols) {
-        if (i != x || j != x) {
+        if (i != x || j != y) {
           count += map[i][j];
         }
       } else count++;


### PR DESCRIPTION
This is a 1-character-delta bugfix for the cave generation code from the marching cubes coding challenge.
  
The `countNeighbors` function counts the number of 1's there are in a 3x3 grid centered at the given `(x, y)`. In this function, we iterate over neighbors at indices `(i,j)`. We only want to count real neighbors and not the node itself, so we should check that `(x,y) != (i,j)`. A small typo slipped in causing the function to check that  `(x, x) != (i, j)`.
