### PR TITLE
Fixed broken link for my previous contribution

### DIFF
--- a/_CodingChallenges/012-lorenzattractor.md
+++ b/_CodingChallenges/012-lorenzattractor.md
@@ -38,7 +38,7 @@ contributions:
     author:
       name: "Juan Carlos Ponce Campuzano"
       url: "https://jcponce.github.io/"
-    url: "https://editor.p5js.org/jcponce/present/JH7nMvdIC"
-    source: "https://editor.p5js.org/jcponce/sketches/JH7nMvdIC"
+    url: "https://editor.p5js.org/jcponce/present/WUmXSTPvr"
+    source: "https://editor.p5js.org/jcponce/sketches/WUmXSTPvr"
 ---
 In this coding challenge, I show you how to visualization the Lorenz Attractor in Processing (Java).


### PR DESCRIPTION
Hi, 

I was re-factoring the code of my contribution and then I don’t know what happen to the “present” link sketch. It does not work anymore:

Broken link: https://editor.p5js.org/jcponce/present/JH7nMvdIC

However, the “sketch” link with code works: https://editor.p5js.org/jcponce/sketches/JH7nMvdIC

Anyway, I decided to create a new link for the sketch that works fine, and I will try to figure out what happened to the previous sketch.

Could you please update the link? Thanks.

<!--
Thank you for contributing to The Coding Train website!

This is a template to get more information about your pull request. To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the preview tab! Feel free to remove all or any portion of the template that is not relevant, as it is mainly designed for community contributions.

You can see the guide at: https://thecodingtrain.com/Guides/community-contribution-guide.html.
-->

### Community Contribution

**Link to live project, video, or image:**

https://editor.p5js.org/jcponce/present/WUmXSTPvr

### Sharing

- [x] I would be happy to have my project shared on The Coding Train's social media!

<!-- If you would like us to tag you in any posts about your work please include your handle below. -->

**Instagram:**

**Twitter:**
