### PR TITLE
add rel attribute to prevent click-jacking

### DIFF
--- a/404.md
+++ b/404.md
@@ -4,5 +4,5 @@ permalink: /404.html
 ---
 <h2> 404 :( </h2>
 <h2>your rainbow is in another train station</h2>
-<p>it was not possible to find the page, visit the <a href="{{ '/' | relative_url }}">Home</a> to find other Coding Challenges. If you think there is a problem report it on <a href="{{ site.github.repository_url }}/issues" target="_blank">Github Issues</a>
+<p>it was not possible to find the page, visit the <a href="{{ '/' | relative_url }}">Home</a> to find other Coding Challenges. If you think there is a problem report it on <a href="{{ site.github.repository_url }}/issues" target="_blank" rel="noopener noreferrer">Github Issues</a>
 </p>

--- a/_jekyll/includes/2-base/navigation.html
+++ b/_jekyll/includes/2-base/navigation.html
@@ -65,7 +65,7 @@
         <ul class="links">
           <li><a href="{{ '/Guides/community-contribution-guide' | relative_url }}">Community Contribution Guide</a>
           </li>
-          <li><a href="{{ site.github.repository_url }}" target="_blank">Github</a></li>
+          <li><a href="{{ site.github.repository_url }}" target="_blank" rel="noopener noreferrer">Github</a></li>
           <li><a href="{{ '/Guides' | relative_url }}">All Guides</a></li>
         </ul>
       </div>

--- a/_jekyll/includes/3-modules/hero-item.html
+++ b/_jekyll/includes/3-modules/hero-item.html
@@ -16,5 +16,5 @@
     {% if include.title %}<span class="hero-title">{{ include.title }}</span>{% endif %}
     <span class="hero-content">{{ include.content }}</span>
   </div>
-  <a href="{{ include.url }}" target="_blank">{{ include.cta }}</a>
+  <a href="{{ include.url }}" target="_blank" rel="noopener noreferrer">{{ include.cta }}</a>
 </div>

--- a/landing-page.html
+++ b/landing-page.html
@@ -33,10 +33,10 @@ permalink: /
       <p>All aboard the Coding Train with Daniel Shiffman, a YouTube channel dedicated to beginner-friendly creative
         coding tutorials and challenges.</p>
       <div class="ctas">
-        <div><a href="{{ site.links.youtube }}?sub_confirmation=1" target="_blank" class="youtube">Subscribe on
+        <div><a href="{{ site.links.youtube }}?sub_confirmation=1" target="_blank" rel="noopener noreferrer" class="youtube">Subscribe on
           YouTube</a></div>
-        <div><a href="{{ site.links.youtube }}join" target="_blank" class="patreon">Become a Member</a></div>
-        <div><a href="{{ site.links.discord }}" target="_blank" class="discord">Join the Discord</a></div>
+        <div><a href="{{ site.links.youtube }}join" target="_blank" rel="noopener noreferrer" class="patreon">Become a Member</a></div>
+        <div><a href="{{ site.links.discord }}" target="_blank" rel="noopener noreferrer" class="discord">Join the Discord</a></div>
       </div>
     </div>
 
@@ -47,7 +47,7 @@ permalink: /
   <h2>Latest Videos</h2>
   <div class="featured-videos">
     {% include 3-modules/video-list.html sortedVideos=featuredVideos %}
-    <a href="{{ site.links.youtube }}" target="_blank" class="more-videos">Watch more videos</a>
+    <a href="{{ site.links.youtube }}" target="_blank" rel="noopener noreferrer" class="more-videos">Watch more videos</a>
   </div>
 
   <h2>Support The Coding Train</h2>


### PR DESCRIPTION
`target="_blank"` is open to click-jacking attacks, so adding `rel="noopener noreferrer"` is a way to prevent that.

As an aside, both `noopener` and `noreferrer` prevent this vulnerability, though `noopener` won't work with some legacy browsers, and newer browsers just ignore `noreferrer`, so adding both is the current accepted best practice.
