### PR TITLE
adding missing html in ml5 8.4

### DIFF
--- a/learning/ml5/8.4-cnn-image-classification/mask/index.html
+++ b/learning/ml5/8.4-cnn-image-classification/mask/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <script src="https://cdn.jsdelivr.net/npm/p5@1.1.9/lib/p5.min.js"></script>
+  <script src="https://unpkg.com/ml5@0.6.0/dist/ml5.min.js"></script>
+  <meta charset="utf-8" />
+
+</head>
+
+<body>
+  <script src="sketch.js"></script>
+</body>
+
+</html>


### PR DESCRIPTION
Noticed that the html for the mask example on ml5 8.4 was missing.