### PR TITLE
Removed invalid community contribution reference

### DIFF
--- a/_CodingChallenges/076-10print.md
+++ b/_CodingChallenges/076-10print.md
@@ -19,10 +19,6 @@ contributions:
   - title: "10PRINT with Perlin Noise"
     author: "Red Hen"
     url: https://codepen.io/RedHenDev/pen/OxOZWM
-  - title: "10PRINT"
-    author: "Tino"
-    url: https://tino1008.github.io/10-Print/
-    source: https://github.com/Tino1008/10-Print
   - title: "Authentic Commodore 64 10PRINT"
     author: "Merijn_DH"
     url: http://merijndh.nl/p5_sketches/10PRINT/


### PR DESCRIPTION
Neither the demo link nor the source code is accessible.
The user might have deleted his GitHub account.

Hope this helps ✌