### PR TITLE
ulam hexagon spiral variant in python

### DIFF
--- a/_CodingChallenges/167-prime-spiral.md
+++ b/_CodingChallenges/167-prime-spiral.md
@@ -122,6 +122,14 @@ contributions:
       url: "https://github.com/dipamsen/"
     url: "https://editor.p5js.org/funplanet/full/sHq2rfZuv"
     source: "https://editor.p5js.org/funplanet/sketches/sHq2rfZuv"
----
+   - title: "Ulam hexagon spiral variant in python"
+    author:
+      name: "Paula Wilson"
+      url: "https://github.com/PWilson-1978"
+    url: "https://github.com/PWilson-1978/ulam-hex-spiral"
+    source: "7thwHM0Yj_U"
+
+    
+  
 
 Why do prime numbers show up as diagonals in a spiral? In this video, I create a visualization in JavaScript (p5.js) of the Ulam Spiral (aka Prime Spiral) named for Polish Mathematician Stanislav Ulan.


### PR DESCRIPTION
I have a 3 radii hexagon and all of the primes line up on the radii associated with 5 and 7.  I have another version that opens a file of primes up to 5000 if the square root of a number is larger, it will fill in the primes between.   I modified the routine that checks for the prime and added a check for the last digit of 5 in the check with division of 2 because any number that has a 5 will be divisible by 5, and then I'm also testing another qualification if the modulo of the value being checked is 1 or 5, it may be a prime. Both print out the lists of prime values at the conclusion of the run.

<!--
Thank you for contributing to The Coding Train website!

This is a template to get more information about your pull request. To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the preview tab! Feel free to remove all or any portion of the template that is not relevant, as it is mainly designed for community contributions.

You can see the guide at: https://thecodingtrain.com/Guides/community-contribution-guide.html.
-->

### Community Contribution

**Link to live project, video, or image:**
<!-- Insert a link here. This makes it easier to see what is being added to the site. -->

### Sharing

- [x] I would be happy to have my project shared on The Coding Train's social media!

<!-- If you would like us to tag you in any posts about your work please include your handle below. -->

**Instagram:**

**Twitter:**
